### PR TITLE
Binding shell assembler and material matrices to Python

### DIFF
--- a/examples/example_shell3D.cpp
+++ b/examples/example_shell3D.cpp
@@ -87,12 +87,6 @@ int main(int argc, char *argv[])
         thickness = 1e0;
         PoissonRatio = 0.3;
     }
-
-    gsMultiBasis<> dbasis(mp);
-
-    gsInfo << "Patches: "<< mp.nPatches() <<", degree: "<< dbasis.minCwiseDegree() <<"\n";
-    gsInfo << dbasis.basis(0)<<"\n";
-
     //! [Define material parameters and geometry per example]
 
     //! [Refine and elevate]
@@ -107,6 +101,12 @@ int main(int argc, char *argv[])
     mp_def = mp;
     gsWriteParaview<>( mp_def    , "mp", 1000, true);
     //! [Refine and elevate]
+
+    gsMultiBasis<> dbasis(mp);
+
+    gsInfo << "Patches: "<< mp.nPatches() <<", degree: "<< dbasis.minCwiseDegree() <<"\n";
+    gsInfo << dbasis.basis(0)<<"\n";
+
 
     //! [Set boundary conditions]
     gsBoundaryConditions<> bc;
@@ -137,9 +137,9 @@ int main(int argc, char *argv[])
             bc.addCondition(boundary::west, condition_type::dirichlet, 0, 0 ,false,i);
         }
 
-        pressure = -1;
+        // pressure = -1;
         refPoint<<0.5,0.5;
-        // tmp << 0,0,-1;
+        tmp << 0,0,-1;
 
     }
     else if (testCase == 1)

--- a/gsKLShell.h
+++ b/gsKLShell.h
@@ -1,0 +1,56 @@
+#include <gsCore/gsTemplateTools.h>
+
+#include <gsKLShell/gsMaterialMatrixBase.h>
+#include <gsKLShell/gsMaterialMatrixBaseDim.h>
+
+#include <gsKLShell/gsMaterialMatrixLinear.h>
+#include <gsKLShell/gsMaterialMatrix.h>
+
+#include <gsKLShell/gsThinShellAssembler.h>
+
+
+namespace gismo
+{
+
+#ifdef GISMO_BUILD_PYBIND11
+
+  namespace py = pybind11;
+
+  void pybind11_init_gsKLShell(py::module &m)
+  {
+    gismo::pybind11_init_gsMaterialMatrixBase( m );
+
+    gismo::pybind11_init_gsMaterialMatrixBaseDim2( m );
+    gismo::pybind11_init_gsMaterialMatrixBaseDim3( m );
+
+    gismo::pybind11_init_gsMaterialMatrixLinear2( m );
+    gismo::pybind11_init_gsMaterialMatrixLinear3( m );
+
+    gismo::pybind11_init_gsMaterialMatrixNH2i( m );
+    gismo::pybind11_init_gsMaterialMatrixNH2c( m );
+
+    gismo::pybind11_init_gsMaterialMatrixNH3i( m );
+    gismo::pybind11_init_gsMaterialMatrixNH3c( m );
+
+    gismo::pybind11_init_gsMaterialMatrixMR2i( m );
+    gismo::pybind11_init_gsMaterialMatrixMR2c( m );
+
+    gismo::pybind11_init_gsMaterialMatrixMR3i( m );
+    gismo::pybind11_init_gsMaterialMatrixMR3c( m );
+
+    gismo::pybind11_init_gsMaterialMatrixOG2i( m );
+    gismo::pybind11_init_gsMaterialMatrixOG2c( m );
+
+    gismo::pybind11_init_gsMaterialMatrixOG3i( m );
+    gismo::pybind11_init_gsMaterialMatrixOG3c( m );
+
+    gismo::pybind11_init_gsThinShellAssemblerBase( m );
+
+    gismo::pybind11_init_gsThinShellAssembler2( m );
+    gismo::pybind11_init_gsThinShellAssembler3( m );
+    gismo::pybind11_init_gsThinShellAssembler3nb( m );
+  }
+
+#endif
+}
+

--- a/gsMaterialMatrix.h
+++ b/gsMaterialMatrix.h
@@ -1194,6 +1194,31 @@ private:
     }
 };
 
+#ifdef GISMO_BUILD_PYBIND11
+
+  /**
+   * @brief Initializes the Python wrapper for the class: gsMaterialMatrixLinear
+   */
+  void pybind11_init_gsMaterialMatrixNH2i(pybind11::module &m);
+  void pybind11_init_gsMaterialMatrixNH2c(pybind11::module &m);
+
+  void pybind11_init_gsMaterialMatrixNH3i(pybind11::module &m);
+  void pybind11_init_gsMaterialMatrixNH3c(pybind11::module &m);
+
+  void pybind11_init_gsMaterialMatrixMR2i(pybind11::module &m);
+  void pybind11_init_gsMaterialMatrixMR2c(pybind11::module &m);
+
+  void pybind11_init_gsMaterialMatrixMR3i(pybind11::module &m);
+  void pybind11_init_gsMaterialMatrixMR3c(pybind11::module &m);
+
+  void pybind11_init_gsMaterialMatrixOG2i(pybind11::module &m);
+  void pybind11_init_gsMaterialMatrixOG2c(pybind11::module &m);
+
+  void pybind11_init_gsMaterialMatrixOG3i(pybind11::module &m);
+  void pybind11_init_gsMaterialMatrixOG3c(pybind11::module &m);
+
+#endif // GISMO_BUILD_PYBIND11
+
 } // namespace
 
 

--- a/gsMaterialMatrix2dComp_.cpp
+++ b/gsMaterialMatrix2dComp_.cpp
@@ -24,5 +24,44 @@ namespace gismo
 
   // OG
   CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,34,true>;
+
+  #ifdef GISMO_BUILD_PYBIND11
+
+    namespace py = pybind11;
+
+    void pybind11_init_gsMaterialMatrixNH2c(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<2,real_t>;
+      using Class = gsMaterialMatrix<2,real_t,11,true>;
+      py::class_<Class,Base>(m, "gsMaterialNH2c")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixMR2c(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<2,real_t>;
+      using Class = gsMaterialMatrix<2,real_t,13,true>;
+      py::class_<Class,Base>(m, "gsMaterialMR2c")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixOG2c(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<2,real_t>;
+      using Class = gsMaterialMatrix<2,real_t,34,true>;
+      py::class_<Class,Base>(m, "gsMaterialOG2c")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+  #endif
 }
 

--- a/gsMaterialMatrix2dIncomp_.cpp
+++ b/gsMaterialMatrix2dIncomp_.cpp
@@ -24,5 +24,45 @@ namespace gismo
 
   // OG
   CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,34,false>;
+
+  #ifdef GISMO_BUILD_PYBIND11
+
+    namespace py = pybind11;
+
+    void pybind11_init_gsMaterialMatrixNH2i(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<2,real_t>;
+      using Class = gsMaterialMatrix<2,real_t,11,false>;
+      py::class_<Class,Base>(m, "gsMaterialNH2i")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixMR2i(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<2,real_t>;
+      using Class = gsMaterialMatrix<2,real_t,13,false>;
+      py::class_<Class,Base>(m, "gsMaterialMR2i")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixOG2i(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<2,real_t>;
+      using Class = gsMaterialMatrix<2,real_t,34,false>;
+      py::class_<Class,Base>(m, "gsMaterialOG2i")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+  #endif
+
 }
 

--- a/gsMaterialMatrix3dComp_.cpp
+++ b/gsMaterialMatrix3dComp_.cpp
@@ -25,5 +25,44 @@ namespace gismo
   // OG
   CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,34,true>;
 
+  #ifdef GISMO_BUILD_PYBIND11
+
+    namespace py = pybind11;
+
+    void pybind11_init_gsMaterialMatrixNH3c(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<3,real_t>;
+      using Class = gsMaterialMatrix<3,real_t,11,true>;
+      py::class_<Class,Base>(m, "gsMaterialNH3c")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixMR3c(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<3,real_t>;
+      using Class = gsMaterialMatrix<3,real_t,13,true>;
+      py::class_<Class,Base>(m, "gsMaterialMR3c")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixOG3c(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<3,real_t>;
+      using Class = gsMaterialMatrix<3,real_t,34,true>;
+      py::class_<Class,Base>(m, "gsMaterialOG3c")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+  #endif
+
 }
 

--- a/gsMaterialMatrix3dIncomp_.cpp
+++ b/gsMaterialMatrix3dIncomp_.cpp
@@ -25,5 +25,44 @@ namespace gismo
   // OG
   CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,34,false>;
 
+  #ifdef GISMO_BUILD_PYBIND11
+
+    namespace py = pybind11;
+
+    void pybind11_init_gsMaterialMatrixNH3i(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<3,real_t>;
+      using Class = gsMaterialMatrix<3,real_t,11,false>;
+      py::class_<Class,Base>(m, "gsMaterialNH3i")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixMR3i(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<3,real_t>;
+      using Class = gsMaterialMatrix<3,real_t,13,false>;
+      py::class_<Class,Base>(m, "gsMaterialMR3i")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixOG3i(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<3,real_t>;
+      using Class = gsMaterialMatrix<3,real_t,34,false>;
+      py::class_<Class,Base>(m, "gsMaterialOG3i")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+      ;
+    }
+
+  #endif
+
 }
 

--- a/gsMaterialMatrixBase.h
+++ b/gsMaterialMatrixBase.h
@@ -198,4 +198,13 @@ protected:
     const gsFunctionSet<T> * m_defpatches;
 };
 
+#ifdef GISMO_BUILD_PYBIND11
+
+  /**
+   * @brief Initializes the Python wrapper for the class: gsMaterialMatrixBase
+   */
+  void pybind11_init_gsMaterialMatrixBase(pybind11::module &m);
+
+#endif // GISMO_BUILD_PYBIND11
+
 } // namespace

--- a/gsMaterialMatrixBaseDim.h
+++ b/gsMaterialMatrixBaseDim.h
@@ -165,6 +165,16 @@ public:
 
 };
 
+#ifdef GISMO_BUILD_PYBIND11
+
+  /**
+   * @brief Initializes the Python wrapper for the class: gsMaterialMatrixBaseDim
+   */
+  void pybind11_init_gsMaterialMatrixBaseDim2(pybind11::module &m);
+  void pybind11_init_gsMaterialMatrixBaseDim3(pybind11::module &m);
+
+#endif // GISMO_BUILD_PYBIND11
+
 } // namespace
 
 #ifndef GISMO_BUILD_LIB

--- a/gsMaterialMatrixBase_.cpp
+++ b/gsMaterialMatrixBase_.cpp
@@ -10,5 +10,53 @@ namespace gismo
 
   CLASS_TEMPLATE_INST gsMaterialMatrixBaseDim<2,real_t>;
   CLASS_TEMPLATE_INST gsMaterialMatrixBaseDim<3,real_t>;
+
+  #ifdef GISMO_BUILD_PYBIND11
+
+  namespace py = pybind11;
+
+  void pybind11_init_gsMaterialMatrixBase(py::module &m)
+  {
+    using Class = gsMaterialMatrixBase<real_t>;
+    py::class_<Class>(m, "gsMaterialMatrixBase")
+
+    // Member functions
+    .def("setOptions", &Class::setOptions, "Sets the options")
+    .def("density_into", &Class::density_into, "Computes the density into a matrix")
+    .def("stretch_into", &Class::stretch_into, "Computes the stretches into a matrix")
+    .def("stretchDir_into", &Class::stretchDir_into, "Computes the stretch directions into a matrix")
+    .def("thickness_into", &Class::thickness_into, "Computes the thickness into a matrix")
+    .def("transform_into", &Class::transform_into, "Computes the stretch transformation into a matrix")
+    .def("eval3D_matrix", &Class::eval3D_matrix, "Evaluates the material matrix")
+    .def("eval3D_vector", &Class::eval3D_vector, "Evaluates the stress vector")
+    .def("eval3D_pstress", &Class::eval3D_pstress, "Evaluates the principal stress vector")
+
+    .def("setYoungsModulus",  &Class::setYoungsModulus,   "Sets the Young's Modulus")
+    .def("setPoissonsRatio",  &Class::setPoissonsRatio,   "Sets the Poisson's Ratio")
+    .def("setRatio"        ,  &Class::setRatio        ,   "Sets the Ratio for MR model")
+    .def("setMu"           ,  &Class::setMu           ,   "Sets the Mu_i for OG model")
+    .def("setAlpha"        ,  &Class::setAlpha        ,   "Sets the Alpha_i for OG model")
+    .def("setDensity"      ,  &Class::setDensity      ,   "Sets the Density")
+    ;
+  }
+
+  void pybind11_init_gsMaterialMatrixBaseDim2(py::module &m)
+  {
+    using Base  = gsMaterialMatrixBase<real_t>;
+    using Class = gsMaterialMatrixBaseDim<2,real_t>;
+    py::class_<Class,Base>(m, "gsMaterialMatrixBaseDim2")
+    ;
+  }
+
+  void pybind11_init_gsMaterialMatrixBaseDim3(py::module &m)
+  {
+    using Base  = gsMaterialMatrixBase<real_t>;
+    using Class = gsMaterialMatrixBaseDim<3,real_t>;
+    py::class_<Class,Base>(m, "gsMaterialMatrixBaseDim3")
+    ;
+  }
+
+  #endif
+
 }
 

--- a/gsMaterialMatrixLinear.h
+++ b/gsMaterialMatrixLinear.h
@@ -315,6 +315,16 @@ protected:
 
 };
 
+#ifdef GISMO_BUILD_PYBIND11
+
+  /**
+   * @brief Initializes the Python wrapper for the class: gsMaterialMatrixLinear
+   */
+  void pybind11_init_gsMaterialMatrixLinear2(pybind11::module &m);
+  void pybind11_init_gsMaterialMatrixLinear3(pybind11::module &m);
+
+#endif // GISMO_BUILD_PYBIND11
+
 } // namespace
 
 

--- a/gsMaterialMatrixLinear_.cpp
+++ b/gsMaterialMatrixLinear_.cpp
@@ -8,5 +8,37 @@ namespace gismo
 {
   CLASS_TEMPLATE_INST gsMaterialMatrixLinear<2,real_t>;
   CLASS_TEMPLATE_INST gsMaterialMatrixLinear<3,real_t>;
+
+  #ifdef GISMO_BUILD_PYBIND11
+
+    namespace py = pybind11;
+
+    void pybind11_init_gsMaterialMatrixLinear2(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<2,real_t>;
+      using Class = gsMaterialMatrixLinear<2,real_t>;
+      py::class_<Class,Base>(m, "gsMaterialMatrixLinear2")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+
+      // Member functions
+      ;
+    }
+
+    void pybind11_init_gsMaterialMatrixLinear3(py::module &m)
+    {
+      using Base = gsMaterialMatrixBaseDim<3,real_t>;
+      using Class = gsMaterialMatrixLinear<3,real_t>;
+      py::class_<Class,Base>(m, "gsMaterialMatrixLinear3")
+
+      // Constructors
+      .def(py::init<gsFunctionSet<real_t>&,gsFunction<real_t>&>())
+
+      // Member functions
+      ;
+    }
+
+  #endif
 }
 

--- a/gsThinShellAssembler.h
+++ b/gsThinShellAssembler.h
@@ -392,6 +392,17 @@ protected:
 
 };
 
+#ifdef GISMO_BUILD_PYBIND11
+
+  /**
+   * @brief Initializes the Python wrapper for the class: gsThinShellAssembler
+   */
+  void pybind11_init_gsThinShellAssembler2(pybind11::module &m);
+  void pybind11_init_gsThinShellAssembler3(pybind11::module &m);
+  void pybind11_init_gsThinShellAssembler3nb(pybind11::module &m);
+
+#endif // GISMO_BUILD_PYBIND11
+
 /**
  * @brief      Base class for the gsThinShellAssembler
  *
@@ -403,7 +414,10 @@ template <class T>
 class gsThinShellAssemblerBase
 {
 public:
-    /// Default empty constructor
+    /// Default deconstructor
+    gsThinShellAssemblerBase() {};
+
+    /// Default deconstructor
     virtual ~gsThinShellAssemblerBase() {};
 
     /// Returns the options of the assembler
@@ -417,6 +431,8 @@ public:
 
     /// Registers a \ref gsPointLoads object for point loads acting on the shell
     virtual void setPointLoads(const gsPointLoads<T> & pLoads) = 0;
+
+    /// Registers a \ref gsPointLoads object for a point mass acting on the shell. The point masss must be 1-dimensional
     virtual void setPointMass(const gsPointLoads<T> & pLoads) = 0;
 
     /**
@@ -631,6 +647,15 @@ virtual   gsDofMapper getMapper() = 0;
     virtual void plotSolution(std::string string, const gsMatrix<T> & solVector) = 0;;
 
 };
+
+#ifdef GISMO_BUILD_PYBIND11
+
+  /**
+   * @brief Initializes the Python wrapper for the class: gsThinShellAssembler
+   */
+  void pybind11_init_gsThinShellAssemblerBase(pybind11::module &m);
+
+#endif // GISMO_BUILD_PYBIND11
 
 } // namespace gismo
 

--- a/gsThinShellAssembler.hpp
+++ b/gsThinShellAssembler.hpp
@@ -158,6 +158,8 @@ void gsThinShellAssembler<d, T, bending>::_initialize()
     m_assembler.setIntegrationElements(m_basis);
     m_assembler.setOptions(m_options);
     
+    GISMO_ASSERT(m_bcs.hasGeoMap(),"No geometry map was assigned to the boundary conditions. Use bc.setGeoMap to assign one!");
+
     // Initialize the geometry maps
     // geometryMap m_ori   = m_assembler.getMap(m_patches);
     // geometryMap m_def   = m_assembler.getMap(*m_defpatches);

--- a/gsThinShellAssembler_.cpp
+++ b/gsThinShellAssembler_.cpp
@@ -22,5 +22,113 @@ namespace gismo
   CLASS_TEMPLATE_INST gsThinShellAssembler<2,real_t,false>;
   CLASS_TEMPLATE_INST gsThinShellAssembler<3,real_t,false>;
   CLASS_TEMPLATE_INST gsThinShellAssembler<3,real_t,true>;
+
+#ifdef GISMO_BUILD_PYBIND11
+
+  namespace py = pybind11;
+
+  void pybind11_init_gsThinShellAssemblerBase(py::module &m)
+  {
+    using Class = gsThinShellAssemblerBase<real_t>;
+    py::class_<Class>(m, "gsThinShellAssemblerBase")
+
+    // Member functions
+    .def("numDofs", &Class::numDofs, "Returns the number of degrees of freedom of the system")
+    .def("setSpaceBasis", &Class::setSpaceBasis, "Sets the basis used for discretization (but not for quadrature)")
+
+    .def("assemble", static_cast<void (Class::*)()> (&Class::assemble),
+          "Assembles the linear system")
+    .def("assemble", static_cast<void (Class::*)(const gsFunctionSet<real_t> &, bool)> (&Class::assemble),
+          "Assembles the nonlinear system (matrix optional)")//,
+          // py::arg("Matrix") = false)
+    .def("assemble", static_cast<void (Class::*)(const gsMatrix<real_t> &     , bool)> (&Class::assemble),
+          "Assembles the nonlinear system (matrix optional)")//,
+          // py::arg("Matrix") = false)
+
+    .def("assembleMatrix", static_cast<void (Class::*)(const gsFunctionSet<real_t> &)> (&Class::assembleMatrix),
+          "Assembles the nonlinear matrix")
+    .def("assembleMatrix", static_cast<void (Class::*)(const gsMatrix<real_t> &     )> (&Class::assembleMatrix),
+          "Assembles the nonlinear matrix")
+
+    .def("assembleMatrix", static_cast<void (Class::*)(const gsFunctionSet<real_t> &, const gsFunctionSet<real_t> &, gsMatrix<real_t> & update)> (&Class::assembleMatrix),
+          "Assembles the nonlinear matrix using the Mixed Integration Point (MIP) method")
+    .def("assembleMatrix", static_cast<void (Class::*)(const gsMatrix<real_t>      &, const gsMatrix<real_t>      &                           )> (&Class::assembleMatrix),
+          "Assembles the nonlinear matrix using the Mixed Integration Point (MIP) method")
+
+    .def("assembleVector", static_cast<void (Class::*)(const gsFunctionSet<real_t> &)> (&Class::assembleVector),
+          "Assembles the nonlinear vector")
+    .def("assembleVector", static_cast<void (Class::*)(const gsMatrix<real_t> &     )> (&Class::assembleVector),
+          "Assembles the nonlinear vector")
+
+    .def("assembleMass", &Class::assembleMass, "Assembles the mass matrix",
+          py::arg("lumped") = false)
+
+    .def("matrix", &Class::matrix, "Returns the assembled matrix"         )
+    .def("rhs"   , &Class::rhs   , "Returns the assembled right-hand side")
+
+    .def("constructSolution", static_cast<void                 (Class::*)(const gsMatrix<real_t> &, gsMultiPatch<real_t> &) const> (&Class::constructSolution),
+          "Constructs the solution as a gsMultiPatch")
+    .def("constructSolution", static_cast<gsMultiPatch<real_t> (Class::*)(const gsMatrix<real_t> &                        ) const> (&Class::constructSolution),
+          "Constructs the solution as a gsMultiPatch")
+
+    .def("constructDisplacement", static_cast<void                 (Class::*)(const gsMatrix<real_t> &, gsMultiPatch<real_t> &) const> (&Class::constructDisplacement),
+          "Constructs the displacements as a gsMultiPatch")
+    .def("constructDisplacement", static_cast<gsMultiPatch<real_t> (Class::*)(const gsMatrix<real_t> &                        ) const> (&Class::constructDisplacement),
+          "Constructs the displacements as a gsMultiPatch")
+    ;
+  }
+
+  void pybind11_init_gsThinShellAssembler2(py::module &m)
+  {
+    using Base = gsThinShellAssemblerBase<real_t>;
+    using Class = gsThinShellAssembler<2,real_t,false>;
+    py::class_<Class,Base>(m, "gsThinShellAssembler2")
+
+      // Constructors
+      .def(py::init<gsMultiPatch<real_t>&,
+                    gsMultiBasis<real_t>&,
+                    gsBoundaryConditions<real_t> &,
+                    gsFunction<real_t> &,
+                    gsMaterialMatrixBase<real_t> * >())
+
+      // Member functions
+      ;
+  }
+
+  void pybind11_init_gsThinShellAssembler3nb(py::module &m)
+  {
+    using Base = gsThinShellAssemblerBase<real_t>;
+    using Class = gsThinShellAssembler<3,real_t,false>;
+    py::class_<Class,Base>(m, "gsThinShellAssembler3nb")
+
+      // Constructors
+      .def(py::init<gsMultiPatch<real_t>&,
+                    gsMultiBasis<real_t>&,
+                    gsBoundaryConditions<real_t> &,
+                    gsFunction<real_t> &,
+                    gsMaterialMatrixBase<real_t> * >())
+
+      // Member functions
+      ;
+  }
+
+  void pybind11_init_gsThinShellAssembler3(py::module &m)
+  {
+    using Base = gsThinShellAssemblerBase<real_t>;
+    using Class = gsThinShellAssembler<3,real_t,true>;
+    py::class_<Class,Base>(m, "gsThinShellAssembler3")
+
+      // Constructors
+      .def(py::init<gsMultiPatch<real_t>&,
+                    gsMultiBasis<real_t>&,
+                    gsBoundaryConditions<real_t> &,
+                    gsFunction<real_t> &,
+                    gsMaterialMatrixBase<real_t> * >())
+
+      // Member functions
+      ;
+  }
+
+#endif
 }
 

--- a/python_examples/example_shell3D.py
+++ b/python_examples/example_shell3D.py
@@ -15,13 +15,16 @@
 """
 
 import os, sys
-gismo_path=os.path.join(os.path.dirname(__file__), "../build/lib")
+gismo_path=os.path.join(os.path.dirname(__file__), "../../../build/lib")
 print("G+Smo path:",gismo_path,"(change if needed).")
 sys.path.append(gismo_path)
 
 import pygismo as gs
 import numpy as np
 import scipy.sparse.linalg as la
+from matplotlib import cm
+import matplotlib.pyplot as plt
+# from mpl_toolkits.mplot3d import Axes3D
 
 ## See gismo/filedata/surfaces/simple.xml for the geometry
 c1 = np.array([0.,0.,1.,1.])
@@ -47,13 +50,13 @@ mp = gs.core.gsMultiPatch()
 mp.addPatch(tspline1)
 
 mp.degreeElevate()
-mp.uniformRefine()
+# mp.uniformRefine()
 
 mb = gs.core.gsMultiBasis(mp)
 
 t = gs.core.gsFunctionExpr("1",3)
 E = gs.core.gsFunctionExpr("1",3)
-nu = gs.core.gsFunctionExpr("0.0",3)
+nu = gs.core.gsFunctionExpr("0.3",3)
 f = gs.core.gsFunctionExpr("0","0","-1",3)
 
 null = gs.core.gsFunctionExpr("0",3)
@@ -77,11 +80,82 @@ vector = assembler.rhs()
 print(assembler.matrix());
 print(assembler.rhs());
 solution = la.spsolve(matrix,vector[:,0])
+print(solution);
 sol = assembler.constructSolution(solution)
-assembler.assembleVector(solution)
-assembler.assembleMatrix(solution)
-print(assembler.matrix());
-print(assembler.rhs());
+# assembler.assembleVector(solution)
+# assembler.assembleMatrix(solution)
+# print(assembler.matrix());
+# print(assembler.rhs());
 
 print("Solution coefficients:\n",sol.patch(0).coefs())
+u = np.array([0.5,0.5])
+print(f"Linear solution on {u[0],u[1]}:\n", sol.patch(0).eval(u))
 
+
+def Residual(resvec):
+    sol = assembler.constructSolution(resvec)
+    assembler.assembleVector(sol)
+    return assembler.rhs()
+
+def Jacobian(resvec):
+    sol = assembler.constructSolution(resvec)
+    assembler.assembleMatrix(sol)
+    return assembler.matrix()
+
+
+
+print("Nonlinear solve...")
+residual = np.linalg.norm(vector)
+residual0 = residual
+residualOld = residual
+update = solution
+resvec = Residual(solution)
+
+itmax = 100
+tol = 1e-6
+for it in range(0,itmax):
+    jacmat = Jacobian(solution)
+    update = la.spsolve(jacmat,resvec[:,0])
+    solution += update
+
+    resvec = Residual(solution)
+    residual = np.linalg.norm(resvec)
+
+    print("Iteration ",it,end="")
+    print(", residue %0.5e" %residual,end="")
+    print(", update norm %0.5e" %np.linalg.norm(update),end="")
+    print(", log(Ri/R0) %0.5e" %np.log(residualOld/residual0),end="")
+    print(", log(Ri+1/R0) %0.5e" %np.log(residual/residual0),end="")
+    print("")
+
+    residualOld = residual
+
+    if (np.linalg.norm(update) < tol):
+        break
+    elif (it+1==itmax):
+        print("Maximum iterations reached")
+
+N = 20
+X = Y = np.linspace(0,1,N)
+XX,YY = np.meshgrid(X,Y)
+
+XX = XX.reshape(N*N)
+YY = YY.reshape(N*N)
+
+u = np.stack([XX,YY])
+print(u)
+
+sol = assembler.constructSolution(solution)
+
+solution = sol.patch(0).eval(u)
+print(solution)
+
+fig = plt.figure()
+ax = fig.add_subplot() # projection='3d'
+
+XX = solution[0,:].reshape((N,N))
+YY = solution[1,:].reshape((N,N))
+ZZ = solution[2,:].reshape((N,N))
+p = ax.contourf(XX,YY,ZZ,cmap=cm.coolwarm)
+fig.colorbar(p)
+plt.show()

--- a/python_examples/example_shell3D.py
+++ b/python_examples/example_shell3D.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+
+""""
+    @file BSpline curve example
+
+    @brief Play with a B-spline curve in Python
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): S. Imperatore
+"""
+
+import os, sys
+gismo_path=os.path.join(os.path.dirname(__file__), "../build/lib")
+print("G+Smo path:",gismo_path,"(change if needed).")
+sys.path.append(gismo_path)
+
+import pygismo as gs
+import numpy as np
+import scipy.sparse.linalg as la
+
+## See gismo/filedata/surfaces/simple.xml for the geometry
+c1 = np.array([0.,0.,1.,1.])
+c2 = np.array([0.,0.,1.,1.])
+ku1 = gs.nurbs.gsKnotVector(c1,1)
+ku2 = gs.nurbs.gsKnotVector(c2,1)
+
+coefs = np.array([
+                    [0     ,0    ,0   ],
+                    [1     ,0    ,0   ],
+                    [0     ,1    ,0   ],
+                    [1     ,1    ,0   ],
+                        ])
+
+
+# Construct basis using knot vectors
+tbasis1 = gs.nurbs.gsTensorBSplineBasis2(ku1,ku2)
+tspline1 = gs.nurbs.gsTensorBSpline2(tbasis1,coefs)
+
+print("Coefficients:\n", tspline1.coefs())
+
+mp = gs.core.gsMultiPatch()
+mp.addPatch(tspline1)
+
+mp.degreeElevate()
+mp.uniformRefine()
+
+mb = gs.core.gsMultiBasis(mp)
+
+t = gs.core.gsFunctionExpr("1",3)
+E = gs.core.gsFunctionExpr("1",3)
+nu = gs.core.gsFunctionExpr("0.0",3)
+f = gs.core.gsFunctionExpr("0","0","-1",3)
+
+null = gs.core.gsFunctionExpr("0",3)
+side = gs.core.side.west
+bcs = gs.pde.gsBoundaryConditions();
+
+for d in range(0,3):
+    for side in [gs.core.side.west, gs.core.side.east, gs.core.side.south, gs.core.side.north]:
+        bcs.addCondition(0,side,gs.pde.bctype.dirichlet,null,0,False,d)
+
+bcs.setGeoMap(mp);
+
+mm = gs.klshell.gsMaterialMatrixLinear3(mp,t)
+mm.setYoungsModulus(E)
+mm.setPoissonsRatio(nu)
+
+assembler = gs.klshell.gsThinShellAssembler3(mp,mb,bcs,f,mm)
+assembler.assemble()
+matrix = assembler.matrix()
+vector = assembler.rhs()
+print(assembler.matrix());
+print(assembler.rhs());
+solution = la.spsolve(matrix,vector[:,0])
+sol = assembler.constructSolution(solution)
+assembler.assembleVector(solution)
+assembler.assembleMatrix(solution)
+print(assembler.matrix());
+print(assembler.rhs());
+
+print("Solution coefficients:\n",sol.patch(0).coefs())
+


### PR DESCRIPTION
Binded the following classes:
- gsThinShellAssemblerBase
- gsThinShellAssembler
- gsMaterialMatrixBase
- gsMaterialMatrixBaseDim
- gsMaterialMatrixLinear
- gsMaterialMatrix

Tested with `example_shell3D.py`