### PR TITLE
Fix compiler warnings for Clang

### DIFF
--- a/examples/example_shell3D_DWR.cpp
+++ b/examples/example_shell3D_DWR.cpp
@@ -364,7 +364,6 @@ int main(int argc, char *argv[])
         mesher.getOptions();
     }
 
-    real_t cummImprovement;
     for (index_t r=0; r!=numRefine+1; r++)
     {
 
@@ -520,8 +519,6 @@ int main(int argc, char *argv[])
 
             gsHBoxContainer<2,real_t> elts;
             index_t c = 0;
-            real_t newError = 0;
-            real_t oldError = 0;
             for (index_t p=0; p < mp.nPieces(); ++p)
             {
             // index_t p=0;
@@ -535,8 +532,6 @@ int main(int argc, char *argv[])
                     box.setAndProjectError(elErrors[c],mesherOpts.getInt("Convergence_alpha"),mesherOpts.getInt("Convergence_beta"));
                     elts.add(box);
                     markRef.add(box);
-                    oldError += box.error();
-                    newError += box.projectedErrorRef();
                     c++;
                 }
             }
@@ -605,22 +600,10 @@ int main(int argc, char *argv[])
             gsWriteParaview(elts,"elts");
 
             // --------------- adaptive refinement ---------------
-            cummImprovement = 0;
             index_t index = std::rand()%container.size();
             gsHBox<2,real_t> refbox = *std::next(container.begin(),index);
             typename gsHBoxContainer<2,real_t>::HContainer hcontainer = gsHBoxUtils<2,real_t>::markAdmissible(refbox,2);
             gsHBoxContainer<2,real_t>refined(hcontainer);
-
-            for (typename gsHBoxContainer<2,real_t>::HIterator hit = refined.begin(); hit!=refined.end(); hit++)
-                for (typename gsHBoxContainer<2,real_t>::Iterator it = hit->begin(); it!=hit->end(); it++)
-                {
-                    auto pred = [it](auto b){return it->isSame(b);};
-                    typename gsHBox<2,real_t>::SortedContainer::iterator found = std::find_if(scontainer.begin(),scontainer.end(),pred);
-                    if (found!=scontainer.end())
-                        cummImprovement += found->error()-found->projectedErrorRef();
-                    else
-                        GISMO_ERROR("Hi");
-                }
 
             mesher.refine(refined);
             gsWriteParaview(refined,"refined");

--- a/examples/example_shell3D_DWR_buckling.cpp
+++ b/examples/example_shell3D_DWR_buckling.cpp
@@ -38,7 +38,6 @@ int main(int argc, char *argv[])
     index_t numRefineIni = 0;
     index_t numElevate = 1;
     bool last = false;
-    bool adaptive = false;
     std::string fn;
 
     real_t E_modulus = 1e6;
@@ -66,8 +65,6 @@ int main(int argc, char *argv[])
     cmd.addInt("r", "refine", "Maximum number of adaptive refinement steps to perform",
                numRefine);
     cmd.addInt("t", "testcase", "Test case: 0: bi-directional, 1: uni-directional", testCase);
-
-    cmd.addInt("A", "adaptivity", "Adaptivity scheme: 0) uniform refinement, 1) adaptive refinement, 2) adaptive refinement and coarsening", adaptivity);
 
     cmd.addReal("L","load", "Load", Load);
 
@@ -213,7 +210,7 @@ int main(int argc, char *argv[])
         real_t b = bbox(1,1)-bbox(1,0);
         real_t r = b/a; // ratio of the plate CHECK
         real_t pi = 3.141592653589793238462;
-        GISMO_ASSERT(r==1,"Only for ratio==1");
+        GISMO_ENSURE(r==1,"Only for ratio==1");
         for (index_t m=1; m!=10; m++)
         {
             for (index_t n=1; n!=10; n++)
@@ -261,7 +258,7 @@ int main(int argc, char *argv[])
         real_t b = bbox(1,1)-bbox(1,0);
         real_t r = b/a; // ratio of the plate CHECK
         real_t pi = 3.141592653589793238462;
-        GISMO_ASSERT(r==1,"Only for ratio==1");
+        GISMO_ENSURE(r==1,"Only for ratio==1");
         for (index_t m=1; m!=10; m++)
         {
             for (index_t n=1; n!=10; n++)

--- a/examples/gsMaterialMatrix_test.cpp
+++ b/examples/gsMaterialMatrix_test.cpp
@@ -94,7 +94,6 @@ int main (int argc, char** argv)
     gsMatrix<> result;
 
     gsExprAssembler<> A(1,1);
-    typedef gsExprAssembler<>::geometryMap geometryMap;
     typedef gsExprAssembler<>::variable    variable;
 
     gsExprEvaluator<> ev(A);

--- a/src/getMaterialMatrix.h
+++ b/src/getMaterialMatrix.h
@@ -144,33 +144,33 @@ gsMaterialMatrixBase<T> * getMaterialMatrix(
         else if ((mat==Material::NH) && (impl==Implementation::Analytical) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::NH) && (impl==Implementation::Generalized) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::NH) && (impl==Implementation::Spectral) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters,rho);
         }
         //--------------------------------------NH Compressible--------------------------------------------------
         else if ((mat==Material::NH) && (impl==Implementation::Analytical) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::NH) && (impl==Implementation::Generalized) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::NH) && (impl==Implementation::Spectral) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         //
         //--------------------------------------NH_ext Incompressible--------------------------------------------------
@@ -182,50 +182,50 @@ gsMaterialMatrixBase<T> * getMaterialMatrix(
         else if ((mat==Material::NH_ext) && (impl==Implementation::Analytical) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH_ext, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::NH_ext) && (impl==Implementation::Generalized) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH_ext, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::NH_ext) && (impl==Implementation::Spectral) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH_ext, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         //
         //--------------------------------------MR Incompressible--------------------------------------------------
         else if ((mat==Material::MR) && (impl==Implementation::Analytical) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::MR) && (impl==Implementation::Generalized) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::MR) && (impl==Implementation::Spectral) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters,rho);
         }
         //---------------------------------------MR Compressible-------------------------------------------------
         else if      ((mat==Material::MR) && (impl==Implementation::Analytical) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::MR) && (impl==Implementation::Generalized) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         else if ((mat==Material::MR) && (impl==Implementation::Spectral) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         //
         //--------------------------------------OG Incompressible--------------------------------------------------
@@ -240,7 +240,7 @@ gsMaterialMatrixBase<T> * getMaterialMatrix(
         else if ((mat==Material::OG) && (impl==Implementation::Spectral) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::OG, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters,rho);
         }
         //---------------------------------------OG Compressible-------------------------------------------------
         else if      ((mat==Material::OG) && (impl==Implementation::Analytical) && (compressibility))
@@ -254,7 +254,7 @@ gsMaterialMatrixBase<T> * getMaterialMatrix(
         else if ((mat==Material::OG) && (impl==Implementation::Spectral) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::OG, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters,rho);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters,rho);
         }
         else
             return NULL;
@@ -307,33 +307,33 @@ gsMaterialMatrixBase<T> * getMaterialMatrix(
         else if ((mat==Material::NH) && (impl==Implementation::Analytical) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters);
         }
         else if ((mat==Material::NH) && (impl==Implementation::Generalized) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters);
         }
         else if ((mat==Material::NH) && (impl==Implementation::Spectral) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters);
         }
         //--------------------------------------NH Compressible--------------------------------------------------
         else if ((mat==Material::NH) && (impl==Implementation::Analytical) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         else if ((mat==Material::NH) && (impl==Implementation::Generalized) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         else if ((mat==Material::NH) && (impl==Implementation::Spectral) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         //
         //--------------------------------------NH_ext Incompressible--------------------------------------------------
@@ -345,50 +345,50 @@ gsMaterialMatrixBase<T> * getMaterialMatrix(
         else if ((mat==Material::NH_ext) && (impl==Implementation::Analytical) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH_ext, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         else if ((mat==Material::NH_ext) && (impl==Implementation::Generalized) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH_ext, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         else if ((mat==Material::NH_ext) && (impl==Implementation::Spectral) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::NH_ext, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         //
         //--------------------------------------MR Incompressible--------------------------------------------------
         else if ((mat==Material::MR) && (impl==Implementation::Analytical) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters);
         }
         else if ((mat==Material::MR) && (impl==Implementation::Generalized) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters);
         }
         else if ((mat==Material::MR) && (impl==Implementation::Spectral) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters);
         }
         //---------------------------------------MR Compressible-------------------------------------------------
         else if      ((mat==Material::MR) && (impl==Implementation::Analytical) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Analytical>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         else if ((mat==Material::MR) && (impl==Implementation::Generalized) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Generalized>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         else if ((mat==Material::MR) && (impl==Implementation::Spectral) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::MR, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         //
         //--------------------------------------OG Incompressible--------------------------------------------------
@@ -403,7 +403,7 @@ gsMaterialMatrixBase<T> * getMaterialMatrix(
         else if ((mat==Material::OG) && (impl==Implementation::Spectral) && (!compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::OG, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,false>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,false>(mp,thickness,parameters);
         }
         //---------------------------------------OG Compressible-------------------------------------------------
         else if      ((mat==Material::OG) && (impl==Implementation::Analytical) && (compressibility))
@@ -417,7 +417,7 @@ gsMaterialMatrixBase<T> * getMaterialMatrix(
         else if ((mat==Material::OG) && (impl==Implementation::Spectral) && (compressibility))
         {
             constexpr index_t id = encodeMat_id<Material::OG, Implementation::Spectral>::id;
-            return new gsMaterialMatrix<d,real_t,id,true>(mp,thickness,parameters);
+            return new gsMaterialMatrixNonlinear<d,real_t,id,true>(mp,thickness,parameters);
         }
         else
             return NULL;

--- a/src/gsMaterialMatrixBase.h
+++ b/src/gsMaterialMatrixBase.h
@@ -625,23 +625,23 @@ public:
         return eval3D_gamma(patch,u,zmat,out);
     }
 
-    virtual void setYoungsModulus(const gsFunction<T> & YoungsModulus)
+    virtual void setYoungsModulus(const gsFunctionSet<T> & YoungsModulus)
     { GISMO_NO_IMPLEMENTATION; }
     virtual const function_ptr getYoungsModulus() const
     { GISMO_NO_IMPLEMENTATION; }
-    virtual void setPoissonsRatio(const gsFunction<T> & PoissonsRatio)
+    virtual void setPoissonsRatio(const gsFunctionSet<T> & PoissonsRatio)
     { GISMO_NO_IMPLEMENTATION; }
     virtual const function_ptr getPoissonsRatio() const
     { GISMO_NO_IMPLEMENTATION; }
-    virtual void setRatio(const gsFunction<T> & Ratio)
+    virtual void setRatio(const gsFunctionSet<T> & Ratio)
     { GISMO_NO_IMPLEMENTATION; }
     virtual const function_ptr getRatio() const
     { GISMO_NO_IMPLEMENTATION; }
-    virtual void setMu(const index_t & i, const gsFunction<T> & Mu_i)
+    virtual void setMu(const index_t & i, const gsFunctionSet<T> & Mu_i)
     { GISMO_NO_IMPLEMENTATION; }
     virtual const function_ptr getMu(const index_t & i) const
     { GISMO_NO_IMPLEMENTATION; }
-    virtual void setAlpha(const index_t & i, const gsFunction<T> & Alpha_i)
+    virtual void setAlpha(const index_t & i, const gsFunctionSet<T> & Alpha_i)
     { GISMO_NO_IMPLEMENTATION; }
     virtual const function_ptr getAlpha(const index_t & i) const
     { GISMO_NO_IMPLEMENTATION; }

--- a/src/gsMaterialMatrixBase.hpp
+++ b/src/gsMaterialMatrixBase.hpp
@@ -1,4 +1,4 @@
-/** @file gsMaterialMatrixNonlinear.hpp
+/** @file gsMaterialMatrixBase.hpp
 
     @brief Provides hyperelastic material matrices
 
@@ -57,71 +57,71 @@ namespace gismo
 //         return mm->print(os);
 
 //     // CompressibleNH2
-//     if ( const gsMaterialMatrix<2,T,11,true> * mm =
-//          dynamic_cast<const gsMaterialMatrix<2,T,11,true> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<2,T,11,true> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<2,T,11,true> *>( this ) )
 //         return mm->print(os);
 //     // CompressibleNH3
-//     if ( const gsMaterialMatrix<3,T,11,true> * mm =
-//          dynamic_cast<const gsMaterialMatrix<3,T,11,true> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<3,T,11,true> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<3,T,11,true> *>( this ) )
 //         return mm->print(os);
 //     // IncompressibleNH2
-//     if ( const gsMaterialMatrix<2,T,11,false> * mm =
-//          dynamic_cast<const gsMaterialMatrix<2,T,11,false> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<2,T,11,false> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<2,T,11,false> *>( this ) )
 //         return mm->print(os);
 //     // IncompressibleNH3
-//     if ( const gsMaterialMatrix<3,T,11,false> * mm =
-//          dynamic_cast<const gsMaterialMatrix<3,T,11,false> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<3,T,11,false> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<3,T,11,false> *>( this ) )
 //         return mm->print(os);
 
 //     // CompressibleNHe2
-//     if ( const gsMaterialMatrix<2,T,12,true> * mm =
-//          dynamic_cast<const gsMaterialMatrix<2,T,12,true> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<2,T,12,true> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<2,T,12,true> *>( this ) )
 //         return mm->print(os);
 //     // CompressibleNHe3
-//     if ( const gsMaterialMatrix<3,T,12,true> * mm =
-//          dynamic_cast<const gsMaterialMatrix<3,T,12,true> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<3,T,12,true> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<3,T,12,true> *>( this ) )
 //         return mm->print(os);
 //     // IncompressibleNHe2
-//     if ( const gsMaterialMatrix<2,T,12,false> * mm =
-//          dynamic_cast<const gsMaterialMatrix<2,T,12,false> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<2,T,12,false> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<2,T,12,false> *>( this ) )
 //         return mm->print(os);
 //     // IncompressibleNHe3
-//     if ( const gsMaterialMatrix<3,T,12,false> * mm =
-//          dynamic_cast<const gsMaterialMatrix<3,T,12,false> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<3,T,12,false> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<3,T,12,false> *>( this ) )
 //         return mm->print(os);
 
 //     // CompressibleMR2
-//     if ( const gsMaterialMatrix<2,T,13,true> * mm =
-//          dynamic_cast<const gsMaterialMatrix<2,T,13,true> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<2,T,13,true> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<2,T,13,true> *>( this ) )
 //         return mm->print(os);
 //     // CompressibleMR3
-//     if ( const gsMaterialMatrix<3,T,13,true> * mm =
-//          dynamic_cast<const gsMaterialMatrix<3,T,13,true> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<3,T,13,true> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<3,T,13,true> *>( this ) )
 //         return mm->print(os);
 //     // IncompressibleMR2
-//     if ( const gsMaterialMatrix<2,T,13,false> * mm =
-//          dynamic_cast<const gsMaterialMatrix<2,T,13,false> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<2,T,13,false> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<2,T,13,false> *>( this ) )
 //         return mm->print(os);
 //     // IncompressibleMR3
-//     if ( const gsMaterialMatrix<3,T,13,false> * mm =
-//          dynamic_cast<const gsMaterialMatrix<3,T,13,false> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<3,T,13,false> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<3,T,13,false> *>( this ) )
 //         return mm->print(os);
 
 //     // CompressibleOG2
-//     if ( const gsMaterialMatrix<2,T,34,true> * mm =
-//          dynamic_cast<const gsMaterialMatrix<2,T,34,true> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<2,T,34,true> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<2,T,34,true> *>( this ) )
 //         return mm->print(os);
 //     // CompressibleOG3
-//     if ( const gsMaterialMatrix<3,T,34,true> * mm =
-//          dynamic_cast<const gsMaterialMatrix<3,T,34,true> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<3,T,34,true> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<3,T,34,true> *>( this ) )
 //         return mm->print(os);
 //     // IncompressibleOG2
-//     if ( const gsMaterialMatrix<2,T,34,false> * mm =
-//          dynamic_cast<const gsMaterialMatrix<2,T,34,false> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<2,T,34,false> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<2,T,34,false> *>( this ) )
 //         return mm->print(os);
 //     // IncompressibleOG3
-//     if ( const gsMaterialMatrix<3,T,34,false> * mm =
-//          dynamic_cast<const gsMaterialMatrix<3,T,34,false> *>( this ) )
+//     if ( const gsMaterialMatrixNonlinear<3,T,34,false> * mm =
+//          dynamic_cast<const gsMaterialMatrixNonlinear<3,T,34,false> *>( this ) )
 //         return mm->print(os);
 
 //     os<<"gsMaterialMatrixBase (type not understood).\n";
@@ -228,40 +228,40 @@ public:
             return gsXml< gsMaterialMatrixLinear<3,T> >::get(node);
 
         if ( s == "CompressibleNH2"    )
-            return gsXml< gsMaterialMatrix<2,T,11,true> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<2,T,11,true> >::get(node);
         if ( s == "CompressibleNH3"    )
-            return gsXml< gsMaterialMatrix<3,T,11,true> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<3,T,11,true> >::get(node);
         if ( s == "IncompressibleNH2"  )
-            return gsXml< gsMaterialMatrix<2,T,11,false> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<2,T,11,false> >::get(node);
         if ( s == "IncompressibleNH3"  )
-            return gsXml< gsMaterialMatrix<3,T,11,false> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<3,T,11,false> >::get(node);
 
         if ( s == "CompressibleNHe2"    )
-            return gsXml< gsMaterialMatrix<2,T,12,true> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<2,T,12,true> >::get(node);
         if ( s == "CompressibleNHe3"    )
-            return gsXml< gsMaterialMatrix<3,T,12,true> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<3,T,12,true> >::get(node);
         if ( s == "IncompressibleNHe2"  )
-            return gsXml< gsMaterialMatrix<2,T,12,false> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<2,T,12,false> >::get(node);
         if ( s == "IncompressibleNHe3"  )
-            return gsXml< gsMaterialMatrix<3,T,12,false> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<3,T,12,false> >::get(node);
 
         if ( s == "CompressibleMR2"    )
-            return gsXml< gsMaterialMatrix<2,T,13,true> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<2,T,13,true> >::get(node);
         if ( s == "CompressibleMR3"    )
-            return gsXml< gsMaterialMatrix<3,T,13,true> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<3,T,13,true> >::get(node);
         if ( s == "IncompressibleMR2"  )
-            return gsXml< gsMaterialMatrix<2,T,13,false> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<2,T,13,false> >::get(node);
         if ( s == "IncompressibleMR3"  )
-            return gsXml< gsMaterialMatrix<3,T,13,false> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<3,T,13,false> >::get(node);
 
         if ( s == "CompressibleOG2"    )
-            return gsXml< gsMaterialMatrix<2,T,34,true> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<2,T,34,true> >::get(node);
         if ( s == "CompressibleOG3"    )
-            return gsXml< gsMaterialMatrix<3,T,34,true> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<3,T,34,true> >::get(node);
         if ( s == "IncompressibleOG2"  )
-            return gsXml< gsMaterialMatrix<2,T,34,false> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<2,T,34,false> >::get(node);
         if ( s == "IncompressibleOG3"  )
-            return gsXml< gsMaterialMatrix<3,T,34,false> >::get(node);
+            return gsXml< gsMaterialMatrixNonlinear<3,T,34,false> >::get(node);
 
         gsWarn<<"gsMaterialMatrixBase: get<MaterialMatrixBase<T>>: No known MaterialMatrix \""<<s<<"\". Error.\n";
         return NULL;
@@ -299,72 +299,72 @@ public:
             return gsXml< gsMaterialMatrixLinear<3,T> >::put(*mm,data);
 
         // CompressibleNH2
-        if ( const gsMaterialMatrix<2,T,11,true> * mm =
-             dynamic_cast<const gsMaterialMatrix<2,T,11,true> *>( obj ) )
-            return gsXml< gsMaterialMatrix<2,T,11,true> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<2,T,11,true> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<2,T,11,true> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<2,T,11,true> >::put(*mm,data);
         // CompressibleNH3
-        if ( const gsMaterialMatrix<3,T,11,true> * mm =
-             dynamic_cast<const gsMaterialMatrix<3,T,11,true> *>( obj ) )
-            return gsXml< gsMaterialMatrix<3,T,11,true> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<3,T,11,true> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<3,T,11,true> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<3,T,11,true> >::put(*mm,data);
         // IncompressibleNH2
-        if ( const gsMaterialMatrix<2,T,11,false> * mm =
-             dynamic_cast<const gsMaterialMatrix<2,T,11,false> *>( obj ) )
-            return gsXml< gsMaterialMatrix<2,T,11,false> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<2,T,11,false> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<2,T,11,false> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<2,T,11,false> >::put(*mm,data);
         // IncompressibleNH3
-        if ( const gsMaterialMatrix<3,T,11,false> * mm =
-             dynamic_cast<const gsMaterialMatrix<3,T,11,false> *>( obj ) )
-            return gsXml< gsMaterialMatrix<3,T,11,false> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<3,T,11,false> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<3,T,11,false> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<3,T,11,false> >::put(*mm,data);
 
         // CompressibleNHe2
-        if ( const gsMaterialMatrix<2,T,12,true> * mm =
-             dynamic_cast<const gsMaterialMatrix<2,T,12,true> *>( obj ) )
-            return gsXml< gsMaterialMatrix<2,T,12,true> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<2,T,12,true> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<2,T,12,true> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<2,T,12,true> >::put(*mm,data);
         // CompressibleNHe3
-        if ( const gsMaterialMatrix<3,T,12,true> * mm =
-             dynamic_cast<const gsMaterialMatrix<3,T,12,true> *>( obj ) )
-            return gsXml< gsMaterialMatrix<3,T,12,true> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<3,T,12,true> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<3,T,12,true> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<3,T,12,true> >::put(*mm,data);
         // IncompressibleNHe2
-        if ( const gsMaterialMatrix<2,T,12,false> * mm =
-             dynamic_cast<const gsMaterialMatrix<2,T,12,false> *>( obj ) )
-            return gsXml< gsMaterialMatrix<2,T,12,false> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<2,T,12,false> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<2,T,12,false> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<2,T,12,false> >::put(*mm,data);
         // IncompressibleNHe3
-        if ( const gsMaterialMatrix<3,T,12,false> * mm =
-             dynamic_cast<const gsMaterialMatrix<3,T,12,false> *>( obj ) )
-            return gsXml< gsMaterialMatrix<3,T,12,false> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<3,T,12,false> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<3,T,12,false> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<3,T,12,false> >::put(*mm,data);
 
         // CompressibleMR2
-        if ( const gsMaterialMatrix<2,T,13,true> * mm =
-             dynamic_cast<const gsMaterialMatrix<2,T,13,true> *>( obj ) )
-            return gsXml< gsMaterialMatrix<2,T,13,true> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<2,T,13,true> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<2,T,13,true> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<2,T,13,true> >::put(*mm,data);
         // CompressibleMR3
-        if ( const gsMaterialMatrix<3,T,13,true> * mm =
-             dynamic_cast<const gsMaterialMatrix<3,T,13,true> *>( obj ) )
-            return gsXml< gsMaterialMatrix<3,T,13,true> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<3,T,13,true> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<3,T,13,true> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<3,T,13,true> >::put(*mm,data);
         // IncompressibleMR2
-        if ( const gsMaterialMatrix<2,T,13,false> * mm =
-             dynamic_cast<const gsMaterialMatrix<2,T,13,false> *>( obj ) )
-            return gsXml< gsMaterialMatrix<2,T,13,false> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<2,T,13,false> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<2,T,13,false> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<2,T,13,false> >::put(*mm,data);
         // IncompressibleMR3
-        if ( const gsMaterialMatrix<3,T,13,false> * mm =
-             dynamic_cast<const gsMaterialMatrix<3,T,13,false> *>( obj ) )
-            return gsXml< gsMaterialMatrix<3,T,13,false> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<3,T,13,false> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<3,T,13,false> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<3,T,13,false> >::put(*mm,data);
 
         // CompressibleOG2
-        if ( const gsMaterialMatrix<2,T,34,true> * mm =
-             dynamic_cast<const gsMaterialMatrix<2,T,34,true> *>( obj ) )
-            return gsXml< gsMaterialMatrix<2,T,34,true> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<2,T,34,true> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<2,T,34,true> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<2,T,34,true> >::put(*mm,data);
         // CompressibleOG3
-        if ( const gsMaterialMatrix<3,T,34,true> * mm =
-             dynamic_cast<const gsMaterialMatrix<3,T,34,true> *>( obj ) )
-            return gsXml< gsMaterialMatrix<3,T,34,true> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<3,T,34,true> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<3,T,34,true> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<3,T,34,true> >::put(*mm,data);
         // IncompressibleOG2
-        if ( const gsMaterialMatrix<2,T,34,false> * mm =
-             dynamic_cast<const gsMaterialMatrix<2,T,34,false> *>( obj ) )
-            return gsXml< gsMaterialMatrix<2,T,34,false> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<2,T,34,false> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<2,T,34,false> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<2,T,34,false> >::put(*mm,data);
         // IncompressibleOG3
-        if ( const gsMaterialMatrix<3,T,34,false> * mm =
-             dynamic_cast<const gsMaterialMatrix<3,T,34,false> *>( obj ) )
-            return gsXml< gsMaterialMatrix<3,T,34,false> >::put(*mm,data);
+        if ( const gsMaterialMatrixNonlinear<3,T,34,false> * mm =
+             dynamic_cast<const gsMaterialMatrixNonlinear<3,T,34,false> *>( obj ) )
+            return gsXml< gsMaterialMatrixNonlinear<3,T,34,false> >::put(*mm,data);
 
         gsWarn<<"gsMaterialMatrixBase: put<MaterialMatrixBase<T>>: No known MaterialMatrix "<< obj <<"Error.\n";
         return NULL;

--- a/src/gsMaterialMatrixBaseDim.h
+++ b/src/gsMaterialMatrixBaseDim.h
@@ -105,43 +105,43 @@ public:
     virtual void defaultOptions() override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual void    density_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const;
+    virtual void    density_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual void  thickness_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const;
+    virtual void  thickness_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual void parameters_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const;
+    virtual void parameters_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_spec2cov(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_spec2cov(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_spec2con(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_spec2con(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_cov2cart(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_cov2cart(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_con2cart(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_con2cart(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_deformation(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_deformation(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_strain(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_strain(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_tensionfield(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const;
+    virtual gsMatrix<T> eval3D_tensionfield(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const override;
     
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_pstretch(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_pstretch(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_pstretchDir(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_pstretchDir(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    virtual gsMatrix<T> eval3D_pstrain(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const;
+    virtual gsMatrix<T> eval3D_pstrain(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z) const override;
 
     virtual bool initialized() const override
     {

--- a/src/gsMaterialMatrixBaseDim.hpp
+++ b/src/gsMaterialMatrixBaseDim.hpp
@@ -682,7 +682,7 @@ gsMatrix<T> gsMaterialMatrixBaseDim<dim,T>::_getGcov_def(index_t k, T z) const
 template <short_t dim, class T>
 gsMatrix<T> gsMaterialMatrixBaseDim<dim,T>::_getGcon_def(index_t k, T z) const
 {
-    gsMatrix<T> Gcov_def = _getGcon_def(k,z);
+    gsMatrix<T> Gcov_def = _getGcov_def(k,z);
     return Gcov_def.inverse();
 }
 

--- a/src/gsMaterialMatrixComposite.h
+++ b/src/gsMaterialMatrixComposite.h
@@ -40,7 +40,7 @@ class gsMaterialMatrixComposite : public gsMaterialMatrixBaseDim<dim,T>
 {
 public:
 
-    GISMO_CLONE_FUNCTION(gsMaterialMatrixComposite)
+    GISMO_OVERRIDE_CLONE_FUNCTION(gsMaterialMatrixComposite)
 
     using Base = gsMaterialMatrixBaseDim<dim,T>;
 
@@ -68,33 +68,33 @@ public:
                             const std::vector< gsFunctionSet<T> *>              & G,
                             const std::vector< gsFunctionSet<T> *>              & alpha         );
 
-    enum MatIntegration isMatIntegrated() const {return MatIntegration::Integrated; }
-    enum MatIntegration isVecIntegrated() const {return MatIntegration::Integrated; }
+    enum MatIntegration isMatIntegrated() const override {return MatIntegration::Integrated; }
+    enum MatIntegration isVecIntegrated() const override {return MatIntegration::Integrated; }
 
     /// @brief Returns the list of default options for assembly
-    gsOptionList & options() {return m_options;}
-    void setOptions(gsOptionList opt) {m_options.update(opt,gsOptionList::addIfUnknown); }
+    gsOptionList & options() override {return m_options;}
+    void setOptions(gsOptionList opt) override {m_options.update(opt,gsOptionList::addIfUnknown); }
 
     // template COM
-    void density_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const;
+    void density_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const override;
     // template COM
-    void pstretch_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+    void pstretch_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const override
     {GISMO_NO_IMPLEMENTATION;}
-    void pstretchDir_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+    void pstretchDir_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const override
     {GISMO_NO_IMPLEMENTATION;}
-    void pstress_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+    void pstress_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const override
     {GISMO_NO_IMPLEMENTATION;}
-    void pstressDir_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+    void pstressDir_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const override
     {GISMO_NO_IMPLEMENTATION;}
 
-    void thickness_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const;
-
-    /// See \ref gsMaterialMatrixBase for details
-    void parameters_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const
-    {GISMO_NO_IMPLEMENTATION;}
+    void thickness_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    void transform_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const
+    void parameters_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const override
+    {GISMO_NO_IMPLEMENTATION;}
+
+    /// See \ref gsMaterialMatrixBase for details
+    void transform_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const override
     {GISMO_NO_IMPLEMENTATION;}
 
     /// See \ref gsMaterialMatrixBase for details
@@ -105,8 +105,8 @@ public:
     void pstressTransform_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const
     {GISMO_NO_IMPLEMENTATION;}
 
-    gsMatrix<T> eval3D_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const;
-    gsMatrix<T> eval3D_vector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const;
+    gsMatrix<T> eval3D_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
+    gsMatrix<T> eval3D_vector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
 
     std::ostream &print(std::ostream &os) const override;
 

--- a/src/gsMaterialMatrixLinear.h
+++ b/src/gsMaterialMatrixLinear.h
@@ -42,7 +42,7 @@ public:
 
     typedef T Scalar_t;
 
-    GISMO_CLONE_FUNCTION(gsMaterialMatrixLinear)
+    GISMO_OVERRIDE_CLONE_FUNCTION(gsMaterialMatrixLinear)
 
     using Base = gsMaterialMatrixBaseDim<dim,T>;
 
@@ -176,7 +176,7 @@ public:
     inline enum MatIntegration isVecIntegrated() const override {return MatIntegration::Constant; }
 
     /// See \ref gsMaterialMatrixBase for details
-    void defaultOptions();
+    void defaultOptions() override;
 
     /// See \ref gsMaterialMatrixBase for details
     gsMatrix<T> eval3D_matrix (const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
@@ -214,23 +214,23 @@ public:
     gsMatrix<T> eval3D_detF (const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
 
     /// Sets the YoungsModulus
-    void setYoungsModulus(const gsFunctionSet<T> & YoungsModulus) { Base::setParameter(0,YoungsModulus); }
+    void setYoungsModulus(const gsFunctionSet<T> & YoungsModulus) override { Base::setParameter(0,YoungsModulus); }
 
     /// Gets the YoungsModulus
-    const function_ptr getYoungsModulus() const { return Base::getParameter(0); }
+    const function_ptr getYoungsModulus() const override { return Base::getParameter(0); }
 
     /// Sets the Poisson's Ratio
-    void setPoissonsRatio(const gsFunctionSet<T> & PoissonsRatio) { Base::setParameter(1,PoissonsRatio); }
+    void setPoissonsRatio(const gsFunctionSet<T> & PoissonsRatio) override { Base::setParameter(1,PoissonsRatio); }
 
     /// Gets the Poisson's Ratio
-    const function_ptr getPoissonsRatio() const { return Base::getParameter(1); }
+    const function_ptr getPoissonsRatio() const override { return Base::getParameter(1); }
 
     /// See \ref gsMaterialMatrixBase for details
     std::ostream &print(std::ostream &os) const override;
 
-    gsMatrix<T> S(const gsMatrix<T> & strain) const;
+    gsMatrix<T> S(const gsMatrix<T> & strain) const override;
 
-    gsMatrix<T> C(const gsMatrix<T> & strain) const;
+    gsMatrix<T> C(const gsMatrix<T> & strain) const override;
 
     /// Computes the vector S as function of the deformation tensor C=FTF
     gsMatrix<T> S(const gsMatrix<T> & C, const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const;

--- a/src/gsMaterialMatrixNonlinear.h
+++ b/src/gsMaterialMatrixNonlinear.h
@@ -44,11 +44,11 @@ template <  short_t dim,
             enum Material mat = decodeMat_id<matId>::material,
             enum Implementation imp  = decodeMat_id<matId>::implementation
          >
-class gsMaterialMatrix :    public gsMaterialMatrixBaseDim<dim,T>
+class gsMaterialMatrixNonlinear :    public gsMaterialMatrixBaseDim<dim,T>
 {
 public:
 
-    GISMO_CLONE_FUNCTION(gsMaterialMatrix)
+    GISMO_OVERRIDE_CLONE_FUNCTION(gsMaterialMatrixNonlinear)
 
     using Base = gsMaterialMatrixBaseDim<dim,T>;
 
@@ -60,7 +60,7 @@ public:
      * @param[in]  mp             Original geometry
      * @param[in]  thickness      Thickness function
      */
-    gsMaterialMatrix(   const gsFunctionSet<T> & mp,
+    gsMaterialMatrixNonlinear(   const gsFunctionSet<T> & mp,
                         const gsFunctionSet<T> & thickness);
 
     /**
@@ -70,7 +70,7 @@ public:
      * @param[in]  thickness  Thickness function
      * @param[in]  pars       Vector with parameters (E, nu)
      */
-    gsMaterialMatrix(   const gsFunctionSet<T> & mp,
+    gsMaterialMatrixNonlinear(   const gsFunctionSet<T> & mp,
                         const gsFunctionSet<T> & thickness,
                         const std::vector<gsFunctionSet<T> *> &pars);
 
@@ -80,7 +80,7 @@ public:
      * @param[in]  thickness  Thickness function
      * @param[in]  pars       Vector with parameters (E, nu)
      */
-    gsMaterialMatrix(   const gsFunctionSet<T> & thickness,
+    gsMaterialMatrixNonlinear(   const gsFunctionSet<T> & thickness,
                         const std::vector<gsFunctionSet<T> *> &pars);
 
     /**
@@ -89,7 +89,7 @@ public:
      * @param[in]  thickness  Thickness function
      * @param[in]  pars       Vector with parameters (E, nu)
      */
-    gsMaterialMatrix(   const gsFunctionSet<T> & thickness,
+    gsMaterialMatrixNonlinear(   const gsFunctionSet<T> & thickness,
                         const std::vector<gsFunctionSet<T> *> &pars,
                         const gsFunctionSet<T> & Density);
 
@@ -101,7 +101,7 @@ public:
      * @param[in]  pars       Vector with parameters (E, nu)
      * @param[in]  Density    Density function
      */
-    gsMaterialMatrix(   const gsFunctionSet<T> & mp,
+    gsMaterialMatrixNonlinear(   const gsFunctionSet<T> & mp,
                         const gsFunctionSet<T> & thickness,
                         const std::vector<gsFunctionSet<T> *> &pars,
                         const gsFunctionSet<T> & Density);
@@ -115,20 +115,20 @@ protected:
      * @param[in]  pars       Vector with parameters (E, nu)
      * @param[in]  Density    Density function
      */
-    gsMaterialMatrix(   const gsFunctionSet<T> * mp,
+    gsMaterialMatrixNonlinear(   const gsFunctionSet<T> * mp,
                         const gsFunctionSet<T> * thickness,
                         const std::vector<gsFunctionSet<T> *> &pars,
                         const gsFunctionSet<T> * Density);
 
 public:
     /// Destructor
-    gsMaterialMatrix() { }
+    gsMaterialMatrixNonlinear() { }
 
     /// See \ref gsMaterialMatrixBase for details
-    inline enum MatIntegration isMatIntegrated() const {return MatIntegration::NotIntegrated; }
+    inline enum MatIntegration isMatIntegrated() const override {return MatIntegration::NotIntegrated; }
 
     /// See \ref gsMaterialMatrixBase for details
-    inline enum MatIntegration isVecIntegrated() const {return MatIntegration::NotIntegrated; }
+    inline enum MatIntegration isVecIntegrated() const override {return MatIntegration::NotIntegrated; }
 
     /// See \ref gsMaterialMatrixBase for details
     void defaultOptions() override;
@@ -155,13 +155,13 @@ public:
     gsMatrix<T> eval3D_vector_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z, enum MaterialOutput out = MaterialOutput::Generic) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    gsMatrix<T> eval3D_CauchyVector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const;
+    gsMatrix<T> eval3D_CauchyVector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    gsMatrix<T> eval3D_pstress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const;
+    gsMatrix<T> eval3D_pstress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    gsMatrix<T> eval3D_pstressDir(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const;
+    gsMatrix<T> eval3D_pstressDir(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
 
     /// See \ref gsMaterialMatrixBase for details
     gsMatrix<T> eval3D_CauchyPStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
@@ -179,42 +179,42 @@ public:
     gsMatrix<T> eval3D_CauchyStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const override;
 
     /// Sets the YoungsModulus
-    void setYoungsModulus(const gsFunctionSet<T> & YoungsModulus);
+    void setYoungsModulus(const gsFunctionSet<T> & YoungsModulus) override;
 
     /// Gets the YoungsModulus
-    const function_ptr getYoungsModulus() const ;
+    const function_ptr getYoungsModulus() const override;
 
     /// Sets the Poisson's Ratio
-    void setPoissonsRatio(const gsFunctionSet<T> & PoissonsRatio);
+    void setPoissonsRatio(const gsFunctionSet<T> & PoissonsRatio) override;
     /// Gets the Poisson's Ratio
-    const function_ptr getPoissonsRatio() const ;
+    const function_ptr getPoissonsRatio() const override;
 
     /// Sets the Ratio for the MR material
-    void setRatio(const gsFunctionSet<T> & Ratio) { _setRatio_impl<mat>(Ratio);}
+    void setRatio(const gsFunctionSet<T> & Ratio) override { _setRatio_impl<mat>(Ratio);}
     /// Gets the Ratio for the MR material
-    const function_ptr getRatio() const { return _getRatio_impl<mat>(); }
+    const function_ptr getRatio() const override { return _getRatio_impl<mat>(); }
 
     /// Sets Mu_i
-    void setMu(const index_t & i, const gsFunctionSet<T> & Mu_i) { _setMu_impl<mat>(i,Mu_i); }
+    void setMu(const index_t & i, const gsFunctionSet<T> & Mu_i) override { _setMu_impl<mat>(i,Mu_i); }
 
     /// Gets Mu_i
-    const function_ptr getMu(const index_t & i) const {return _getMu_impl<mat>(i);}
+    const function_ptr getMu(const index_t & i) const override {return _getMu_impl<mat>(i);}
 
     /// Sets Alpha_i
-    void setAlpha(const index_t & i, const gsFunctionSet<T> & Alpha_i) { _setAlpha_impl<mat>(i,Alpha_i); }
+    void setAlpha(const index_t & i, const gsFunctionSet<T> & Alpha_i) override { _setAlpha_impl<mat>(i,Alpha_i); }
 
     /// Gets Alpha_i
-    const function_ptr getAlpha(const index_t & i) const {return _getAlpha_impl<mat>(i);}
+    const function_ptr getAlpha(const index_t & i) const override {return _getAlpha_impl<mat>(i);}
 
     /// See \ref gsMaterialMatrixBase for details
     std::ostream &print(std::ostream &os) const override;
 
 public:
-    /// Shared pointer for gsMaterialMatrix
-    typedef memory::shared_ptr< gsMaterialMatrix > Ptr;
+    /// Shared pointer for gsMaterialMatrixNonlinear
+    typedef memory::shared_ptr< gsMaterialMatrixNonlinear > Ptr;
 
-    /// Unique pointer for gsMaterialMatrix
-    typedef memory::unique_ptr< gsMaterialMatrix > uPtr;
+    /// Unique pointer for gsMaterialMatrixNonlinear
+    typedef memory::unique_ptr< gsMaterialMatrixNonlinear > uPtr;
 
 protected:
     /**
@@ -1224,7 +1224,7 @@ private:
 #ifdef GISMO_WITH_PYBIND11
 
   /**
-   * @brief Initializes the Python wrapper for the class: gsMaterialMatrix
+   * @brief Initializes the Python wrapper for the class: gsMaterialMatrixNonlinear
    */
   void pybind11_init_gsMaterialMatrixNH2i(pybind11::module &m);
   void pybind11_init_gsMaterialMatrixNH2c(pybind11::module &m);

--- a/src/gsMaterialMatrixNonlinear.hpp
+++ b/src/gsMaterialMatrixNonlinear.hpp
@@ -84,7 +84,7 @@ namespace gismo
 {
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::gsMaterialMatrix(
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::gsMaterialMatrixNonlinear(
                                         const gsFunctionSet<T> & mp,
                                         const gsFunctionSet<T> & thickness
                                         )
@@ -95,47 +95,47 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::gsMaterialMatrix(
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::gsMaterialMatrix(
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::gsMaterialMatrixNonlinear(
                                         const gsFunctionSet<T> & mp,
                                         const gsFunctionSet<T> & thickness,
                                         const std::vector<gsFunctionSet<T> *> &pars
                                         )
                                         :
-                                        gsMaterialMatrix(&mp,&thickness,pars,nullptr)
+                                        gsMaterialMatrixNonlinear(&mp,&thickness,pars,nullptr)
 {}
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::gsMaterialMatrix(
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::gsMaterialMatrixNonlinear(
                                     const gsFunctionSet<T> & mp,
                                     const gsFunctionSet<T> & thickness,
                                     const std::vector<gsFunctionSet<T> *> &pars,
                                     const gsFunctionSet<T> & Density
                                     )
                                     :
-                                    gsMaterialMatrix(&mp,&thickness,pars,&Density)
+                                    gsMaterialMatrixNonlinear(&mp,&thickness,pars,&Density)
 {}
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::gsMaterialMatrix(
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::gsMaterialMatrixNonlinear(
                                     const gsFunctionSet<T> & thickness,
                                     const std::vector<gsFunctionSet<T> *> &pars
                                     )
                                     :
-                                    gsMaterialMatrix(nullptr,&thickness,pars,nullptr)
+                                    gsMaterialMatrixNonlinear(nullptr,&thickness,pars,nullptr)
 {}
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::gsMaterialMatrix(
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::gsMaterialMatrixNonlinear(
                                     const gsFunctionSet<T> & thickness,
                                     const std::vector<gsFunctionSet<T> *> &pars,
                                     const gsFunctionSet<T> & Density
                                     )
                                     :
-                                    gsMaterialMatrix(nullptr,&thickness,pars,&Density)
+                                    gsMaterialMatrixNonlinear(nullptr,&thickness,pars,&Density)
 {}
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::gsMaterialMatrix(
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::gsMaterialMatrixNonlinear(
                                     const gsFunctionSet<T> * mp,
                                     const gsFunctionSet<T> * thickness,
                                     const std::vector<gsFunctionSet<T> *> &pars,
@@ -150,7 +150,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::gsMaterialMatrix(
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-std::ostream & gsMaterialMatrix<dim,T,matId,comp,mat,imp>::print(std::ostream &os) const
+std::ostream & gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::print(std::ostream &os) const
 {
     os  <<"---------------------------------------------------------------------\n"
             <<"---------------------Hyperelastic Material Info----------------------\n"
@@ -192,21 +192,21 @@ std::ostream & gsMaterialMatrix<dim,T,matId,comp,mat,imp>::print(std::ostream &o
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-void gsMaterialMatrix<dim,T,matId,comp,mat,imp>::defaultOptions()
+void gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::defaultOptions()
 {
     Base::defaultOptions();
     m_options.addInt("NumGauss","Number of Gaussian points through thickness",4);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-void gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_initialize()
+void gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_initialize()
 {
     // Set default options
     this->defaultOptions();
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-void gsMaterialMatrix<dim,T,matId,comp,mat,imp>::pstretch_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+void gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::pstretch_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
 {
     this->_computePoints(patch,u);
     _pstretch_into_impl<comp>(patch,u,result);
@@ -215,7 +215,7 @@ void gsMaterialMatrix<dim,T,matId,comp,mat,imp>::pstretch_into(const index_t pat
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 typename std::enable_if<!_comp, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_pstretch_into_impl(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_pstretch_into_impl(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
 {
     Base::pstretch_into(patch,u,result);
 }
@@ -223,7 +223,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_pstretch_into_impl(const index_t pa
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 typename std::enable_if<_comp, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_pstretch_into_impl(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_pstretch_into_impl(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
 {
     result.resize(3, u.cols());
     std::pair<gsVector<T>,gsMatrix<T>> res;
@@ -254,7 +254,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_pstretch_into_impl(const index_t pa
 
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-void gsMaterialMatrix<dim,T,matId,comp,mat,imp>::pstretchDir_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+void gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::pstretchDir_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
 {
     this->_computePoints(patch,u);
     _pstretchDir_into_impl<comp>(patch,u,result);
@@ -263,7 +263,7 @@ void gsMaterialMatrix<dim,T,matId,comp,mat,imp>::pstretchDir_into(const index_t 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 typename std::enable_if<!_comp, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_pstretchDir_into_impl(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_pstretchDir_into_impl(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
 {
     Base::pstretchDir_into(patch,u,result);
 }
@@ -271,7 +271,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_pstretchDir_into_impl(const index_t
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 typename std::enable_if<_comp, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_pstretchDir_into_impl(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_pstretchDir_into_impl(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
 {
     result.resize(9, u.cols());
     std::pair<gsVector<T>,gsMatrix<T>> res;
@@ -301,7 +301,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_pstretchDir_into_impl(const index_t
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_matrix_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_matrix_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z, enum MaterialOutput out) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -313,7 +313,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_matrix_C(const gs
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_mat==Material::SvK, gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     this->_computePoints(patch,u);
     gsMatrix<T> result = _eval3D_Incompressible_matrix_C(Cmat,patch, u, z);
@@ -323,7 +323,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<!_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     this->_computePoints(patch,u);
     gsMatrix<T> result = _eval3D_Incompressible_matrix_C(Cmat,patch, u, z);
@@ -333,7 +333,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     this->_computePoints(patch,u);
     gsMatrix<T> result = _eval3D_Compressible_matrix_C(Cmat,patch, u, z);
@@ -341,7 +341,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_C_impl(const gsMatrix
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_dmatrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_dmatrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
 {
     // return gsMatrix<T>::Zero(27,u.cols()*z.rows());
 
@@ -369,7 +369,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_dmatrix(const ind
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl(const index_t patch, const gsVector<T> & u, const T z) const
+constexpr gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::dCijkl(const index_t patch, const gsVector<T> & u, const T z) const
 {
     return dCijkl_impl<mat,comp>(patch,u,z);
 }
@@ -377,7 +377,7 @@ constexpr gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl(const i
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<!(!_comp && _mat==Material::NH), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_impl(const index_t patch, const gsVector<T> & u, const T z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::dCijkl_impl(const index_t patch, const gsVector<T> & u, const T z) const
 {
     gsMatrix<T> result;
     Cfun<dim,T> Cfunc(this,patch,u,z);
@@ -394,7 +394,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_impl(const index_t patch, con
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<(!_comp && _mat==Material::NH), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_impl(const index_t patch, const gsVector<T> & u, const T z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::dCijkl_impl(const index_t patch, const gsVector<T> & u, const T z) const
 {
     gsMatrix<T> dCdC(3,9);
     dCdC(0,0) = dCijkl_dCmn(0,0,0,0,  0,0); // C1111dC11
@@ -436,7 +436,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_impl(const index_t patch, con
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_dCmn(const index_t i, const index_t j, const index_t k, const index_t l, const index_t m, const index_t n) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::dCijkl_dCmn(const index_t i, const index_t j, const index_t k, const index_t l, const index_t m, const index_t n) const
 {
     return dCijkl_dCmn_impl<mat,comp>(i,j,k,l,m,n);
 }
@@ -449,7 +449,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_dCmn(const index_
 // }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dgconij_dCkl(const gsMatrix<T> & gcon, const index_t i, const index_t j, const index_t k, const index_t l) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dgconij_dCkl(const gsMatrix<T> & gcon, const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     return -1./2. * ( gcon(i,k) * gcon(j,l) + gcon(i,l) * gcon(j,k) );
 }
@@ -457,7 +457,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dgconij_dCkl(const gsMa
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<(!_comp && _mat==Material::NH), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_dCmn_impl(const index_t i, const index_t j, const index_t k, const index_t l, const index_t m, const index_t n) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::dCijkl_dCmn_impl(const index_t i, const index_t j, const index_t k, const index_t l, const index_t m, const index_t n) const
 {
     // --------------------------
     // Neo-Hookean
@@ -500,13 +500,13 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_dCmn_impl(const index_t i, co
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<!(!_comp && _mat==Material::NH), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::dCijkl_dCmn_impl(const index_t i, const index_t j, const index_t k, const index_t l, const index_t m, const index_t n) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::dCijkl_dCmn_impl(const index_t i, const index_t j, const index_t k, const index_t l, const index_t m, const index_t n) const
 {
     GISMO_NO_IMPLEMENTATION;
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -518,7 +518,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_matrix(const inde
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_mat==Material::SvK, gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     this->_computePoints(patch,u);
     gsMatrix<T> result = _eval3D_Incompressible_matrix(patch, u, z);
@@ -528,7 +528,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t pa
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<!_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     this->_computePoints(patch,u);
     gsMatrix<T> result = _eval3D_Incompressible_matrix(patch, u, z);
@@ -538,7 +538,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t pa
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     this->_computePoints(patch,u);
     gsMatrix<T> result = _eval3D_Compressible_matrix(patch, u, z);
@@ -546,25 +546,25 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_matrix_impl(const index_t pa
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_vector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_vector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
 {
     return this->eval3D_stress(patch,u,z,out);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_vector_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_vector_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z, enum MaterialOutput out) const
 {
     return this->eval3D_stress_C(Cmat,patch,u,z,out);
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_CauchyVector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_CauchyVector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
 {
     return this->eval3D_CauchyStress(patch,u,z,out);
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_pstress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_pstress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
 {
     gsMatrix<T> Smat = eval3D_stress(patch,u,z,out);
     gsMatrix<T> result(2, u.cols() * z.rows());
@@ -594,7 +594,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_pstress(const ind
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_pstressDir(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_pstressDir(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
 {
     gsMatrix<T> Smat = eval3D_stress(patch,u,z,out);
     gsMatrix<T> result(2, u.cols() * z.rows());
@@ -624,7 +624,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_pstressDir(const 
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_CauchyPStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_CauchyPStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput out) const
 {
     gsMatrix<T> Smat = eval3D_CauchyStress(patch,u,z,out);
     gsMatrix<T> result(2, u.cols() * z.rows());
@@ -656,7 +656,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_CauchyPStress(con
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_stress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput ) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_stress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput ) const
 {
     this->_computePoints(patch,u);
     return this->_eval3D_stress_impl<mat,comp>(patch,u,z);
@@ -665,7 +665,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_stress(const inde
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_mat==Material::SvK, gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_stress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Incompressible_stress(patch, u, z);
     return result;
@@ -674,7 +674,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_impl(const index_t pa
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<!_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_stress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Incompressible_stress(patch, u, z);
     return result;
@@ -683,14 +683,14 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_impl(const index_t pa
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_stress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Compressible_stress(patch, u, z);
     return result;
 }
 
 template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_stress_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z, enum MaterialOutput out) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_stress_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z, enum MaterialOutput out) const
 {
     this->_computePoints(patch,u);
     return this->_eval3D_stress_C_impl<mat,comp>(Cmat,patch,u,z);
@@ -699,7 +699,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_stress_C(const gs
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_mat==Material::SvK, gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_stress_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     gsMatrix<T> result = _eval3D_Incompressible_stress_C(Cmat,patch, u, z);
     return result;
@@ -708,7 +708,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_C_impl(const gsMatrix
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<!_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_stress_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     gsMatrix<T> result = _eval3D_Incompressible_stress_C(Cmat,patch, u, z);
     return result;
@@ -717,14 +717,14 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_C_impl(const gsMatrix
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_stress_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_stress_C_impl(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     gsMatrix<T> result = _eval3D_Compressible_stress_C(Cmat,patch, u, z);
     return result;
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_stress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_stress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -773,7 +773,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_str
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_stress_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_stress_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -822,7 +822,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_str
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_stress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_stress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // gsInfo<<"TO DO: evaluate moments using thickness";
     // Input: u in-plane points
@@ -858,7 +858,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_s
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_stress_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_stress_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     // gsInfo<<"TO DO: evaluate moments using thickness";
     // Input: u in-plane points
@@ -889,7 +889,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_s
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_detF(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput ) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_detF(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput ) const
 {
     this->_computePoints(patch,u);
     return this->_eval3D_detF_impl<mat,comp>(patch,u,z);
@@ -898,7 +898,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_detF(const index_
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_mat==Material::SvK, gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_detF_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_detF_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Incompressible_detF(patch, u, z);
     return result;
@@ -907,7 +907,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_detF_impl(const index_t patc
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<!_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_detF_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_detF_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Incompressible_detF(patch, u, z);
     return result;
@@ -916,14 +916,14 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_detF_impl(const index_t patc
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_detF_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_detF_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Compressible_detF(patch, u, z);
     return result;
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_detF(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_detF(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -950,7 +950,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_det
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_detF(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_detF(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result(1, u.cols() * z.rows());
     result.setOnes();
@@ -958,7 +958,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_d
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_CauchyStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput ) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::eval3D_CauchyStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T> & z, enum MaterialOutput ) const
 {
     this->_computePoints(patch,u);
     return this->_eval3D_CauchyStress_impl<mat,comp>(patch,u,z);
@@ -967,7 +967,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::eval3D_CauchyStress(cons
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_mat==Material::SvK, gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_CauchyStress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_CauchyStress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Incompressible_CauchyStress(patch, u, z);
     return result;
@@ -976,7 +976,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_CauchyStress_impl(const inde
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<!_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_CauchyStress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_CauchyStress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Incompressible_CauchyStress(patch, u, z);
     return result;
@@ -985,21 +985,21 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_CauchyStress_impl(const inde
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 typename std::enable_if<_comp && !(_mat==Material::SvK), gsMatrix<T>>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_CauchyStress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_CauchyStress_impl(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     gsMatrix<T> result = _eval3D_Compressible_CauchyStress(patch, u, z);
     return result;
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_CauchyStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_CauchyStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
     // Output: (n=u.cols(), m=z.rows())
     //          [(u1,z1) (u2,z1) ..  (un,z1), (u1,z2) ..  (un,z2), ..,  (u1,zm) .. (un,zm)]
 
-    gsMatrix<T> Smat = _eval3D_Compressible_CauchyStress(patch,u,z);
+    gsMatrix<T> Smat = _eval3D_Compressible_stress(patch,u,z);
 
     gsMatrix<T> result(3, u.cols() * z.rows());
     result.setZero();
@@ -1022,32 +1022,32 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_Cau
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_CauchyStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_CauchyStress(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // Same as _eval_Incompressible_vector, since J=1
     return _eval3D_Incompressible_stress(patch,u,z);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-void gsMaterialMatrix<dim,T,matId,comp,mat,imp>::setYoungsModulus(const gsFunctionSet<T> & YoungsModulus)
+void gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::setYoungsModulus(const gsFunctionSet<T> & YoungsModulus)
 {
     Base::setParameter(0,YoungsModulus);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr gsMaterialMatrix<dim,T,matId,comp,mat,imp>::getYoungsModulus() const
+const typename gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::function_ptr gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::getYoungsModulus() const
 {
     return Base::getParameter(0);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-void gsMaterialMatrix<dim,T,matId,comp,mat,imp>::setPoissonsRatio(const gsFunctionSet<T> & PoissonsRatio)
+void gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::setPoissonsRatio(const gsFunctionSet<T> & PoissonsRatio)
 {
     Base::setParameter(1,PoissonsRatio);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr gsMaterialMatrix<dim,T,matId,comp,mat,imp>::getPoissonsRatio() const
+const typename gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::function_ptr gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::getPoissonsRatio() const
 {
     return Base::getParameter(1);
 }
@@ -1055,7 +1055,7 @@ const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr gsMateri
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 typename std::enable_if<_mat==Material::MR, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setRatio_impl(const gsFunctionSet<T> & Ratio)
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_setRatio_impl(const gsFunctionSet<T> & Ratio)
 {
     Base::setParameter(2,Ratio);
 }
@@ -1063,23 +1063,23 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setRatio_impl(const gsFunctionSet<T
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 typename std::enable_if<_mat!=Material::MR, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setRatio_impl(const gsFunctionSet<T> & Ratio)
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_setRatio_impl(const gsFunctionSet<T> & Ratio)
 {
     GISMO_NO_IMPLEMENTATION;
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
-typename std::enable_if<_mat==Material::MR, const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr >::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_getRatio_impl() const
+typename std::enable_if<_mat==Material::MR, const typename gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::function_ptr >::type
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_getRatio_impl() const
 {
     return Base::getParameter(2);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
-typename std::enable_if<_mat!=Material::MR, const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr >::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_getRatio_impl() const
+typename std::enable_if<_mat!=Material::MR, const typename gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::function_ptr >::type
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_getRatio_impl() const
 {
     GISMO_NO_IMPLEMENTATION;
 }
@@ -1087,7 +1087,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_getRatio_impl() const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 typename std::enable_if<_mat==Material::OG, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setMu_impl(const index_t & i, const gsFunctionSet<T> & Mu_i)
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_setMu_impl(const index_t & i, const gsFunctionSet<T> & Mu_i)
 {
     Base::setParameter(2+2*i,Mu_i);
 }
@@ -1095,23 +1095,23 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setMu_impl(const index_t & i, const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 typename std::enable_if<_mat!=Material::OG, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setMu_impl(const index_t & i, const gsFunctionSet<T> & Mu_i)
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_setMu_impl(const index_t & i, const gsFunctionSet<T> & Mu_i)
 {
     GISMO_NO_IMPLEMENTATION;
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
-typename std::enable_if<_mat==Material::OG, const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr >::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_getMu_impl(const index_t & i) const
+typename std::enable_if<_mat==Material::OG, const typename gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::function_ptr >::type
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_getMu_impl(const index_t & i) const
 {
     return Base::getParameter(2+2*i);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
-typename std::enable_if<_mat!=Material::OG, const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr >::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_getMu_impl(const index_t & i) const
+typename std::enable_if<_mat!=Material::OG, const typename gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::function_ptr >::type
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_getMu_impl(const index_t & i) const
 {
     GISMO_NO_IMPLEMENTATION;
 }
@@ -1119,7 +1119,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_getMu_impl(const index_t & i) const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 typename std::enable_if<_mat==Material::OG, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setAlpha_impl(const index_t & i, const gsFunctionSet<T> & Alpha_i)
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_setAlpha_impl(const index_t & i, const gsFunctionSet<T> & Alpha_i)
 {
     Base::setParameter(2+2*i+1,Alpha_i);
 }
@@ -1127,30 +1127,30 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setAlpha_impl(const index_t & i, co
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 typename std::enable_if<_mat!=Material::OG, void>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_setAlpha_impl(const index_t & i, const gsFunctionSet<T> & Alpha_i)
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_setAlpha_impl(const index_t & i, const gsFunctionSet<T> & Alpha_i)
 {
     GISMO_NO_IMPLEMENTATION;
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
-typename std::enable_if<_mat==Material::OG, const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr >::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_getAlpha_impl(const index_t & i) const
+typename std::enable_if<_mat==Material::OG, const typename gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::function_ptr >::type
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_getAlpha_impl(const index_t & i) const
 {
     return Base::getParameter(2+2*i+1);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
-typename std::enable_if<_mat!=Material::OG, const typename gsMaterialMatrix<dim,T,matId,comp,mat,imp>::function_ptr >::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_getAlpha_impl(const index_t & i) const
+typename std::enable_if<_mat!=Material::OG, const typename gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::function_ptr >::type
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_getAlpha_impl(const index_t & i) const
 {
     GISMO_NO_IMPLEMENTATION;
 }
 
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_matrix_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_matrix_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     // gsInfo<<"TO DO: evaluate moments using thickness";
     // Input: u in-plane points
@@ -1187,7 +1187,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_m
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // gsInfo<<"TO DO: evaluate moments using thickness";
     // Input: u in-plane points
@@ -1228,7 +1228,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Incompressible_m
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl(const index_t i, const index_t j, const index_t k, const index_t l) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     GISMO_ENSURE( ( (i < 2) && (j < 2) && (k < 2) && (l < 2) ) , "Index out of range. i="<<i<<", j="<<j<<", k="<<k<<", l="<<l);
     GISMO_ENSURE(!comp,"Material model is not incompressible?");
@@ -1239,7 +1239,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl(const index_t i, 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::SvK && _imp==Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     // --------------------------
     // Saint Venant Kirchhoff
@@ -1257,7 +1257,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::NH && _imp==Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     // --------------------------
     // Neo-Hookean
@@ -1269,7 +1269,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::MR && _imp==Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     // --------------------------
     // Mooney-Rivlin
@@ -1295,7 +1295,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_imp==Implementation::Spectral, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     // --------------------------
     // Stretch-based implementations
@@ -1352,7 +1352,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_imp==Implementation::Generalized, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     // --------------------------
     // General implementations
@@ -1366,9 +1366,9 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const i
 // template <enum Material _mat>
 // // OTHER CASES!
 // typename std::enable_if<(_mat >= 30) && !(_mat==0) && !(_mat==2) && !(_mat==3), T>::type
-// gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
+// gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
 // {
-//     GISMO_ERROR("Material model unknown (model = "<<_mat<<"). Use gsMaterialMatrix<dim,T,matId,comp,mat,imp>::info() to see the options.");
+//     GISMO_ERROR("Material model unknown (model = "<<_mat<<"). Use gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::info() to see the options.");
 // }
 
         // else if (m_material==4)
@@ -1379,7 +1379,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const i
 
 // Condensation of the 3D tensor for compressible materials
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     GISMO_ENSURE(c.cols()==c.rows(),"Matrix c must be square");
     GISMO_ENSURE(c.cols()==3,"Matrix c must be 3x3");
@@ -1394,7 +1394,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl(const index_t i, 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Implementation _imp>
 constexpr typename std::enable_if< _imp==Implementation::Spectral, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // static condensation is done before the projection
     this->_computeStretch(c,m_data.mine().m_gcon_ori);
@@ -1404,14 +1404,14 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Implementation _imp>
 constexpr typename std::enable_if<!(_imp==Implementation::Spectral), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     return _Cijkl3D(i,j,k,l,c,cinv) - ( _Cijkl3D(i,j,2,2,c,cinv) * _Cijkl3D(2,2,k,l,c,cinv) ) / _Cijkl3D(2,2,2,2,c,cinv);
 }
 
 // 3D tensor for compressible materials
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl3D(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     GISMO_ENSURE( ( (i <3) && (j <3) && (k <3) && (l <3) ) , "Index out of range. i="<<i<<", j="<<j<<", k="<<k<<", l="<<l);
     return _Cijkl3D_impl<mat,imp>(i,j,k,l,c,cinv);
@@ -1420,7 +1420,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D(const index_t i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::SvK && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     GISMO_ERROR("Compressible material matrix requested, but not needed. How?");
 }
@@ -1428,7 +1428,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::NH && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // Neo-Hookean
@@ -1452,7 +1452,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::MR && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // Mooney-Rivlin
@@ -1487,7 +1487,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::NH_ext && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // Neo-Hookean 2
@@ -1503,7 +1503,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_imp == Implementation::Spectral, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // Stretch-based implementations
@@ -1567,7 +1567,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_imp == Implementation::Generalized, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // General implementations
@@ -1582,7 +1582,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const
 // - Call that eval matrix inside the TFT given the u,z where the strain is also evaluated
 
 // template <short_t dim, class T, index_t matId, bool comp, enum Material mat, enum Implementation imp >
-// gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_C(const gsMatrix<T> & Cmat) const
+// gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_C(const gsMatrix<T> & Cmat) const
 // {
 //     gsMatrix<T> result(9, u.cols() * z.rows());
 //     result.setZero();
@@ -1613,10 +1613,10 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cijkl3D_impl(const index_t i, const
         - m_Cinv
 */
 // template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-// T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij(const index_t i, const index_t j) const { _Sij(i,j,NULL,NULL); }
+// T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij(const index_t i, const index_t j) const { _Sij(i,j,NULL,NULL); }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij(const index_t i, const index_t j) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij(const index_t i, const index_t j) const
 {
     return _Sij_impl<mat,imp>(i,j);
 }
@@ -1624,7 +1624,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij(const index_t i, co
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::SvK && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
 {
     GISMO_ERROR("Not implemented");
 }
@@ -1632,7 +1632,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::NH && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
 {
     // --------------------------
     // Neo-Hoookean
@@ -1644,7 +1644,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::MR && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
 {
     // --------------------------
     // Mooney-Rivlin
@@ -1667,7 +1667,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_imp == Implementation::Spectral, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
 {
     T tmp = 0.0;
     gsMatrix<T> C(3,3);
@@ -1689,7 +1689,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_imp == Implementation::Generalized, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j) const
 {
     // --------------------------
     // Generalized
@@ -1700,7 +1700,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     return _Sij_impl<mat,imp>(i,j,c,cinv);
 }
@@ -1708,7 +1708,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij(const index_t i, co
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::NH && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // Neo-Hoookean
@@ -1728,7 +1728,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::MR && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // Mooney-Rivlin
@@ -1755,7 +1755,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_mat==Material::NH_ext && _imp == Implementation::Analytical, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // Neo-Hookean 2
@@ -1768,7 +1768,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_imp == Implementation::Spectral, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     T tmp = 0.0;
     this->_computeStretch(c,m_data.mine().m_gcon_ori);
@@ -1784,7 +1784,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, enum Implementation _imp>
 constexpr typename std::enable_if<_imp == Implementation::Generalized, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     // --------------------------
     // Generalized
@@ -1795,7 +1795,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sij_impl(const index_t i, const ind
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sii(const index_t i) const // principle stresses
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sii(const index_t i) const // principle stresses
 {
     gsMatrix<T> C(3,3);
     C.setZero();
@@ -1805,14 +1805,14 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sii(const index_t i) co
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sii(const index_t i, const gsMatrix<T> & c) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sii(const index_t i, const gsMatrix<T> & c) const
 {
     this->_computeStretch(c,m_data.mine().m_gcon_ori);
     return _Sa(i);
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_C33(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_C33(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -1886,7 +1886,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_C33
 
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_C33(const gsMatrix<T> & Cmat, const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_C33(const gsMatrix<T> & Cmat, const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -1959,7 +1959,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_C33
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_matrix_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_matrix_C(const gsMatrix<T> & Cmat, const index_t patch, const gsVector<T> & u, const T z) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -2009,7 +2009,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_mat
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
+gsMatrix<T> gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z) const
 {
     // Input: j index in-plane point
     //        z out-of-plane coordinate (through thickness) in R1 (z)
@@ -2064,7 +2064,7 @@ gsMatrix<T> gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_eval3D_Compressible_mat
 //                                          INCOMPRESSIBLE
 // ---------------------------------------------------------------------------------------------------------------------------------
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi(const index_t i, const index_t j) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi(const index_t i, const index_t j) const
 {
     GISMO_ENSURE( ( (i < 3) && (j < 3) ) , "Index out of range. i="<<i<<", j="<<j);
     GISMO_ENSURE(!comp,"Material model is not incompressible?");
@@ -2075,7 +2075,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi(const index_t i, c
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::NH, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
     return 0.5 * mu * m_data.mine().m_Gcon_ori(i,j);
@@ -2084,7 +2084,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const in
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::MR, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
     T c2 = mu/(m_data.mine().m_parvals.at(2)+1);
@@ -2106,7 +2106,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const in
 
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi(const index_t i, const index_t j, const index_t k, const index_t l) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     GISMO_ENSURE( ( (i < 3) && (j < 3) && (k < 3) && (l < 3) ) , "Index out of range. i="<<i<<", j="<<j<<", k="<<k<<", l="<<l);
     GISMO_ENSURE(!comp,"Material model is not incompressible?");
@@ -2117,7 +2117,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi(const index_t i, 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::NH, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     return 0.0;
 }
@@ -2125,7 +2125,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::MR, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l) const
 {
     T tmp;
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
@@ -2152,7 +2152,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const i
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dI_1(const index_t i, const index_t j) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dI_1(const index_t i, const index_t j) const
 {
     return m_data.mine().m_Gcon_ori(i,j);
 }
@@ -2160,7 +2160,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dI_1(const index_t i, c
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dI_2(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dI_2(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     T traceCt = m_data.mine().m_Gcov_def(0,0)*m_data.mine().m_Gcon_ori(0,0) +
                 m_data.mine().m_Gcov_def(0,1)*m_data.mine().m_Gcon_ori(0,1) +
@@ -2172,7 +2172,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dI_2(const index_t i, c
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     GISMO_ENSURE(imp==Implementation::Generalized,"Not generalized implementation");
     return _dPsi_impl<mat>(i,j,c,cinv);
@@ -2183,7 +2183,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi(const index_t i, c
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::NH, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
     T traceCt = m_data.mine().m_Gcov_def(0,0)*m_data.mine().m_Gcon_ori(0,0) +
@@ -2197,7 +2197,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const in
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::MR, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
     T traceCt = m_data.mine().m_Gcov_def(0,0)*m_data.mine().m_Gcon_ori(0,0) +
@@ -2216,7 +2216,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const in
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::NH_ext, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
     T lambda = m_data.mine().m_parvals.at(0) * m_data.mine().m_parvals.at(1) / ( (1. + m_data.mine().m_parvals.at(1))*(1.-2.*m_data.mine().m_parvals.at(1)));
@@ -2226,7 +2226,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_impl(const index_t i, const in
 // To do: add more models for volumetric part.
 // Here, beta=2.
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_vol(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_vol(const index_t i, const index_t j, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     T K  = m_data.mine().m_parvals.at(0) / ( 3 - 6 * m_data.mine().m_parvals.at(1));
     return K * 0.25 * (m_data.mine().m_J_sq - 1.0) * cinv(i,j);
@@ -2235,7 +2235,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_vol(const index_t 
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     GISMO_ENSURE( ( (i < 3) && (j < 3) && (k < 3) && (l < 3) ) , "Index out of range. i="<<i<<", j="<<j<<", k="<<k<<", l="<<l);
     GISMO_ENSURE(comp,"Material model is not compressible?");
@@ -2246,7 +2246,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi(const index_t i, 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::NH, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     GISMO_ENSURE(3 - 6 * m_data.mine().m_parvals.at(1) != 0, "Bulk modulus is infinity for compressible material model. Try to use incompressible models.");
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
@@ -2265,7 +2265,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::MR, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     GISMO_ENSURE(3 - 6 * m_data.mine().m_parvals.at(1) != 0, "Bulk modulus is infinity for compressible material model. Try to use incompressible models.");
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
@@ -2295,7 +2295,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat>
 constexpr typename std::enable_if<_mat==Material::NH_ext, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
     T dCinv = - 1./2.*( cinv(i,k)*cinv(j,l) + cinv(i,l)*cinv(j,k) );
@@ -2304,7 +2304,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_impl(const index_t i, const i
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_vol(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_vol(const index_t i, const index_t j, const index_t k, const index_t l, const gsMatrix<T> & c, const gsMatrix<T> & cinv) const
 {
     T dCinv = - 1./2.*( cinv(i,k)*cinv(j,l) + cinv(i,l)*cinv(j,k) );
     T K  = m_data.mine().m_parvals.at(0) / ( 3 - 6 * m_data.mine().m_parvals.at(1));
@@ -2318,7 +2318,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_vol(const index_t
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da(const index_t a) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da(const index_t a) const
 {
     GISMO_ENSURE( a < 3 , "Index out of range. a="<<a);
     return _dPsi_da_impl<mat,comp>(a);
@@ -2327,7 +2327,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da(const index_t a
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<_comp && (_mat==Material::NH), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 {
     GISMO_ENSURE( a < 3 , "Index out of range. a="<<a);
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
@@ -2341,7 +2341,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<!_comp && (_mat==Material::NH), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
     T _dI_1a = 2*m_data.mine().m_stretches(a);
@@ -2351,7 +2351,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<_comp && (_mat==Material::MR), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
     T I_1   = m_data.mine().m_stretches(0)*m_data.mine().m_stretches(0) + m_data.mine().m_stretches(1)*m_data.mine().m_stretches(1) + m_data.mine().m_stretches(2)*m_data.mine().m_stretches(2);
@@ -2371,7 +2371,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<!_comp && (_mat==Material::MR), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
     T I_1   = m_data.mine().m_stretches(0)*m_data.mine().m_stretches(0) + m_data.mine().m_stretches(1)*m_data.mine().m_stretches(1) + m_data.mine().m_stretches(2)*m_data.mine().m_stretches(2);
@@ -2386,7 +2386,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<_comp && (_mat==Material::OG), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 {
     GISMO_ENSURE(3 - 6 * m_data.mine().m_parvals.at(1) != 0, "Bulk modulus is infinity for compressible material model. Try to use incompressible models.");
     T tmp = 0.0;
@@ -2404,7 +2404,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<!_comp && (_mat==Material::OG), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 {
     T tmp = 0.0;
     index_t n = (m_pars.size()-2)/2;
@@ -2421,7 +2421,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<_comp && (_mat==Material::NH_ext), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
     T _dI_1a = 2*m_data.mine().m_stretches(a);
@@ -2433,7 +2433,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_impl(const index_t a) const
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_vol(const index_t a) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi_da_vol(const index_t a) const
 {
     GISMO_ENSURE(3 - 6 * m_data.mine().m_parvals.at(1) != 0, "Bulk modulus is infinity for compressible material model. Try to use incompressible models.");
     T beta  = -2.0;
@@ -2444,7 +2444,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi_da_vol(const index
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab(const index_t a, const index_t b) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab(const index_t a, const index_t b) const
 {
     GISMO_ENSURE( ( (a < 3) && (b < 3) ) , "Index out of range. a="<<a<<", b="<<b);
     return _d2Psi_dab_impl<mat,comp>(a,b);
@@ -2453,7 +2453,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab(const index_t
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<_comp && (_mat==Material::NH), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
 
@@ -2473,7 +2473,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, con
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<!_comp && (_mat==Material::NH), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
     T d2I_1 = 2*delta(a,b);
@@ -2483,7 +2483,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, con
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<_comp && (_mat==Material::MR), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
 
@@ -2520,7 +2520,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, con
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<!_comp && (_mat==Material::MR), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
 {
     GISMO_ENSURE(m_pars.size()==3,"Mooney-Rivlin model needs to be a 3 parameter model");
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
@@ -2539,7 +2539,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, con
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<_comp && (_mat==Material::OG), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
 {
     T tmp = 0.0;
     index_t n = (m_pars.size()-2)/2;
@@ -2562,7 +2562,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, con
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<!_comp && (_mat==Material::OG), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
 {
     T tmp = 0.0;
     index_t n = (m_pars.size()-2)/2;
@@ -2579,7 +2579,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, con
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <enum Material _mat, bool _comp>
 constexpr typename std::enable_if<_comp && (_mat==Material::NH_ext), T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, const index_t b) const
 {
     T mu = m_data.mine().m_parvals.at(0) / (2 * (1 + m_data.mine().m_parvals.at(1)));
     T d2I_1 = 2*delta(a,b);
@@ -2589,7 +2589,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_impl(const index_t a, con
 }
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_vol(const index_t a, const index_t b) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi_dab_vol(const index_t a, const index_t b) const
 {
     GISMO_ENSURE(3 - 6 * m_data.mine().m_parvals.at(1) != 0, "Bulk modulus is infinity for compressible material model. Try to use incompressible models.");
     m_data.mine().m_J_sq = math::pow(m_data.mine().m_stretches(0)*m_data.mine().m_stretches(1)*m_data.mine().m_stretches(2),2.0);
@@ -2602,7 +2602,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi_dab_vol(const ind
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dJ_da(const index_t a) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dJ_da(const index_t a) const
 {
     return 1.0/m_data.mine().m_stretches(a);
 }
@@ -2610,7 +2610,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dJ_da(const index_t a) 
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2J_dab(const index_t a, const index_t b) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2J_dab(const index_t a, const index_t b) const
 {
     return (a==b) ? 0.0 : 1.0  / ( m_data.mine().m_stretches(a) * m_data.mine().m_stretches(b) );
 }
@@ -2618,7 +2618,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2J_dab(const index_t a
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_p() const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_p() const
 {
     return m_data.mine().m_stretches(2) * _dPsi_da(2);
 }
@@ -2626,7 +2626,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_p() const
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dp_da(const index_t a) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dp_da(const index_t a) const
 {
     if (a==2)
         return m_data.mine().m_stretches(2) * _d2Psi_dab(2,a) + _dPsi_da(2);
@@ -2639,7 +2639,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dp_da(const index_t a) 
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sa(const index_t a) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sa(const index_t a) const
 {
    return _Sa_impl<comp>(a);
 }
@@ -2647,7 +2647,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sa(const index_t a) con
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 constexpr typename std::enable_if<_comp, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sa_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sa_impl(const index_t a) const
 {
     return 1.0/m_data.mine().m_stretches(a) * _dPsi_da(a);
 }
@@ -2655,7 +2655,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sa_impl(const index_t a) const
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 constexpr typename std::enable_if<!_comp, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sa_impl(const index_t a) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Sa_impl(const index_t a) const
 {
     return 1.0/m_data.mine().m_stretches(a) * (_dPsi_da(a) - _p() * _dJ_da(a) );
 }
@@ -2663,7 +2663,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Sa_impl(const index_t a) const
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dSa_db(const index_t a, const index_t b) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dSa_db(const index_t a, const index_t b) const
 {
     return _dSa_db_impl<comp>(a,b);
 }
@@ -2671,7 +2671,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dSa_db(const index_t a,
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 constexpr typename std::enable_if<_comp, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dSa_db_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dSa_db_impl(const index_t a, const index_t b) const
 {
     T tmp = 1.0/m_data.mine().m_stretches(a) * _d2Psi_dab(a,b);
     if (a==b)
@@ -2682,7 +2682,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dSa_db_impl(const index_t a, const 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 constexpr typename std::enable_if<!_comp, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dSa_db_impl(const index_t a, const index_t b) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dSa_db_impl(const index_t a, const index_t b) const
 {
     T tmp = 1.0/m_data.mine().m_stretches(a) * ( _d2Psi_dab(a,b) - _dp_da(a)*_dJ_da(b) - _dp_da(b)*_dJ_da(a) - _p() * _d2J_dab(a,b) );
     if (a==b)
@@ -2693,7 +2693,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dSa_db_impl(const index_t a, const 
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cabcd(const index_t a, const index_t b, const index_t c, const index_t d) const
+constexpr T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cabcd(const index_t a, const index_t b, const index_t c, const index_t d) const
 {
     return _Cabcd_impl<comp>(a,b,c,d);
 }
@@ -2701,7 +2701,7 @@ constexpr T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cabcd(const index_t a, 
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 constexpr typename std::enable_if<_comp, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cabcd_impl(const index_t a, const index_t b, const index_t c, const index_t d) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cabcd_impl(const index_t a, const index_t b, const index_t c, const index_t d) const
 {
     // Compute part with stress tensor involved.
     T frac = 0.0;
@@ -2728,7 +2728,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cabcd_impl(const index_t a, const i
 template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
 template <bool _comp>
 constexpr typename std::enable_if<!_comp, T>::type
-gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cabcd_impl(const index_t a, const index_t b, const index_t c, const index_t d) const
+gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_Cabcd_impl(const index_t a, const index_t b, const index_t c, const index_t d) const
 {
     // Compute part with stress tensor involved.
     T frac = 0.0;
@@ -2756,7 +2756,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cabcd_impl(const index_t a, const i
 //--------------------------------------------------------------------------------------------------------------------------------------
 
 // template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-// T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_dPsi(const index_t a) const
+// T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_dPsi(const index_t a) const
 // {
 //     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
 
@@ -2786,7 +2786,7 @@ gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_Cabcd_impl(const index_t a, const i
 // }
 
 // template <short_t dim, class T, short_t matId, bool comp, enum Material mat, enum Implementation imp >
-// T gsMaterialMatrix<dim,T,matId,comp,mat,imp>::_d2Psi(const index_t a, const index_t b) const
+// T gsMaterialMatrixNonlinear<dim,T,matId,comp,mat,imp>::_d2Psi(const index_t a, const index_t b) const
 // {
 //     T mu = m_data.mine().m_parvals.at(0) / (2. * (1. + m_data.mine().m_parvals.at(1)));
 
@@ -2821,14 +2821,14 @@ namespace internal
 ///
 /// \ingroup KLShell
 template<short_t d, class T, bool comp>
-class gsXml< gsMaterialMatrix<d,T,11,comp> >
+class gsXml< gsMaterialMatrixNonlinear<d,T,11,comp> >
 {
 private:
     gsXml() { }
-    typedef gsMaterialMatrix<d,T,11,comp> Object;
+    typedef gsMaterialMatrixNonlinear<d,T,11,comp> Object;
 
 public:
-    GSXML_COMMON_FUNCTIONS(gsMaterialMatrix<TMPLA4(d,T,11,comp)>);
+    GSXML_COMMON_FUNCTIONS(gsMaterialMatrixNonlinear<TMPLA4(d,T,11,comp)>);
     static std::string tag ()  { return "MaterialMatrix"; }
     static std::string type ()
     {
@@ -2854,14 +2854,14 @@ public:
 ///
 /// \ingroup KLShell
 template<short_t d, class T, bool comp>
-class gsXml< gsMaterialMatrix<d,T,12,comp> >
+class gsXml< gsMaterialMatrixNonlinear<d,T,12,comp> >
 {
 private:
     gsXml() { }
-    typedef gsMaterialMatrix<d,T,12,comp> Object;
+    typedef gsMaterialMatrixNonlinear<d,T,12,comp> Object;
 
 public:
-    GSXML_COMMON_FUNCTIONS(gsMaterialMatrix<TMPLA4(d,T,12,comp)>);
+    GSXML_COMMON_FUNCTIONS(gsMaterialMatrixNonlinear<TMPLA4(d,T,12,comp)>);
     static std::string tag ()  { return "MaterialMatrix"; }
     static std::string type ()
     {
@@ -2887,14 +2887,14 @@ public:
 ///
 /// \ingroup KLShell
 template<short_t d, class T, bool comp>
-class gsXml< gsMaterialMatrix<d,T,13,comp> >
+class gsXml< gsMaterialMatrixNonlinear<d,T,13,comp> >
 {
 private:
     gsXml() { }
-    typedef gsMaterialMatrix<d,T,13,comp> Object;
+    typedef gsMaterialMatrixNonlinear<d,T,13,comp> Object;
 
 public:
-    GSXML_COMMON_FUNCTIONS(gsMaterialMatrix<TMPLA4(d,T,13,comp)>);
+    GSXML_COMMON_FUNCTIONS(gsMaterialMatrixNonlinear<TMPLA4(d,T,13,comp)>);
     static std::string tag ()  { return "MaterialMatrix"; }
     static std::string type ()
     {
@@ -2920,14 +2920,14 @@ public:
 ///
 /// \ingroup KLShell
 template<short_t d, class T, bool comp>
-class gsXml< gsMaterialMatrix<d,T,34,comp> >
+class gsXml< gsMaterialMatrixNonlinear<d,T,34,comp> >
 {
 private:
     gsXml() { }
-    typedef gsMaterialMatrix<d,T,34,comp> Object;
+    typedef gsMaterialMatrixNonlinear<d,T,34,comp> Object;
 
 public:
-    GSXML_COMMON_FUNCTIONS(gsMaterialMatrix<TMPLA4(d,T,34,comp)>);
+    GSXML_COMMON_FUNCTIONS(gsMaterialMatrixNonlinear<TMPLA4(d,T,34,comp)>);
     static std::string tag ()  { return "MaterialMatrix"; }
     static std::string type ()
     {

--- a/src/gsMaterialMatrixNonlinear2dComp_.cpp
+++ b/src/gsMaterialMatrixNonlinear2dComp_.cpp
@@ -8,22 +8,22 @@ namespace gismo
   // Material matrix <dimension, real_t, material model, compressibility>
 
   // NH
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,11,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,21,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,31,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,11,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,21,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,31,true>;
 
   // NH_ext
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,12,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,22,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,32,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,12,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,22,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,32,true>;
 
   // MR
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,13,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,23,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,33,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,13,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,23,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,33,true>;
 
   // OG
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,34,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,34,true>;
 
   #ifdef GISMO_WITH_PYBIND11
 
@@ -32,7 +32,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixNH2c(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<2,real_t>;
-      using Class = gsMaterialMatrix<2,real_t,11,true>;
+      using Class = gsMaterialMatrixNonlinear<2,real_t,11,true>;
       py::class_<Class,Base>(m, "gsMaterialNH2c")
 
       // Constructors
@@ -43,7 +43,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixMR2c(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<2,real_t>;
-      using Class = gsMaterialMatrix<2,real_t,13,true>;
+      using Class = gsMaterialMatrixNonlinear<2,real_t,13,true>;
       py::class_<Class,Base>(m, "gsMaterialMR2c")
 
       // Constructors
@@ -54,7 +54,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixOG2c(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<2,real_t>;
-      using Class = gsMaterialMatrix<2,real_t,34,true>;
+      using Class = gsMaterialMatrixNonlinear<2,real_t,34,true>;
       py::class_<Class,Base>(m, "gsMaterialOG2c")
 
       // Constructors

--- a/src/gsMaterialMatrixNonlinear2dIncomp_.cpp
+++ b/src/gsMaterialMatrixNonlinear2dIncomp_.cpp
@@ -8,22 +8,22 @@ namespace gismo
   // Material matrix <dimension, real_t, material model, compressibility>
 
   // NH
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,11,false>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,21,false>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,31,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,11,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,21,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,31,false>;
 
   // NH_ext does not exist for incomp models
-  // CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,12,false>;
-  // CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,22,false>;
-  // CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,32,false>;
+  // CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,12,false>;
+  // CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,22,false>;
+  // CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,32,false>;
 
   // MR
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,13,false>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,23,false>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,33,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,13,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,23,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,33,false>;
 
   // OG
-  CLASS_TEMPLATE_INST gsMaterialMatrix<2,real_t,34,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<2,real_t,34,false>;
 
   #ifdef GISMO_WITH_PYBIND11
 
@@ -32,7 +32,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixNH2i(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<2,real_t>;
-      using Class = gsMaterialMatrix<2,real_t,11,false>;
+      using Class = gsMaterialMatrixNonlinear<2,real_t,11,false>;
       py::class_<Class,Base>(m, "gsMaterialNH2i")
 
       // Constructors
@@ -43,7 +43,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixMR2i(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<2,real_t>;
-      using Class = gsMaterialMatrix<2,real_t,13,false>;
+      using Class = gsMaterialMatrixNonlinear<2,real_t,13,false>;
       py::class_<Class,Base>(m, "gsMaterialMR2i")
 
       // Constructors
@@ -54,7 +54,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixOG2i(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<2,real_t>;
-      using Class = gsMaterialMatrix<2,real_t,34,false>;
+      using Class = gsMaterialMatrixNonlinear<2,real_t,34,false>;
       py::class_<Class,Base>(m, "gsMaterialOG2i")
 
       // Constructors

--- a/src/gsMaterialMatrixNonlinear3dComp_.cpp
+++ b/src/gsMaterialMatrixNonlinear3dComp_.cpp
@@ -8,22 +8,22 @@ namespace gismo
   // Material matrix <dimension, real_t, material model, compressibility>
 
   // NH
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,11,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,21,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,31,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,11,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,21,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,31,true>;
 
   // NH_ext
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,12,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,22,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,32,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,12,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,22,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,32,true>;
 
   // MR
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,13,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,23,true>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,33,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,13,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,23,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,33,true>;
 
   // OG
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,34,true>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,34,true>;
 
   #ifdef GISMO_WITH_PYBIND11
 
@@ -32,7 +32,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixNH3c(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<3,real_t>;
-      using Class = gsMaterialMatrix<3,real_t,11,true>;
+      using Class = gsMaterialMatrixNonlinear<3,real_t,11,true>;
       py::class_<Class,Base>(m, "gsMaterialNH3c")
 
       // Constructors
@@ -43,7 +43,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixMR3c(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<3,real_t>;
-      using Class = gsMaterialMatrix<3,real_t,13,true>;
+      using Class = gsMaterialMatrixNonlinear<3,real_t,13,true>;
       py::class_<Class,Base>(m, "gsMaterialMR3c")
 
       // Constructors
@@ -54,7 +54,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixOG3c(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<3,real_t>;
-      using Class = gsMaterialMatrix<3,real_t,34,true>;
+      using Class = gsMaterialMatrixNonlinear<3,real_t,34,true>;
       py::class_<Class,Base>(m, "gsMaterialOG3c")
 
       // Constructors

--- a/src/gsMaterialMatrixNonlinear3dIncomp_.cpp
+++ b/src/gsMaterialMatrixNonlinear3dIncomp_.cpp
@@ -8,22 +8,22 @@ namespace gismo
   // Material matrix <dimension, real_t, material model, compressibility>
 
   // NH
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,11,false>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,21,false>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,31,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,11,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,21,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,31,false>;
 
   // NH_ext does not exist for incomp models
-  // CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,12,false>;
-  // CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,22,false>;
-  // CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,32,false>;
+  // CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,12,false>;
+  // CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,22,false>;
+  // CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,32,false>;
 
   // MR
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,13,false>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,23,false>;
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,33,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,13,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,23,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,33,false>;
 
   // OG
-  CLASS_TEMPLATE_INST gsMaterialMatrix<3,real_t,34,false>;
+  CLASS_TEMPLATE_INST gsMaterialMatrixNonlinear<3,real_t,34,false>;
 
   #ifdef GISMO_WITH_PYBIND11
 
@@ -32,7 +32,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixNH3i(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<3,real_t>;
-      using Class = gsMaterialMatrix<3,real_t,11,false>;
+      using Class = gsMaterialMatrixNonlinear<3,real_t,11,false>;
       py::class_<Class,Base>(m, "gsMaterialNH3i")
 
       // Constructors
@@ -43,7 +43,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixMR3i(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<3,real_t>;
-      using Class = gsMaterialMatrix<3,real_t,13,false>;
+      using Class = gsMaterialMatrixNonlinear<3,real_t,13,false>;
       py::class_<Class,Base>(m, "gsMaterialMR3i")
 
       // Constructors
@@ -54,7 +54,7 @@ namespace gismo
     void pybind11_init_gsMaterialMatrixOG3i(py::module &m)
     {
       using Base = gsMaterialMatrixBaseDim<3,real_t>;
-      using Class = gsMaterialMatrix<3,real_t,34,false>;
+      using Class = gsMaterialMatrixNonlinear<3,real_t,34,false>;
       py::class_<Class,Base>(m, "gsMaterialOG3i")
 
       // Constructors

--- a/src/gsMaterialMatrixTFT.h
+++ b/src/gsMaterialMatrixTFT.h
@@ -55,7 +55,7 @@ public:
     typedef typename gsFunctionSet<T>::Ptr function_ptr;
 
     // Define clone functions
-    GISMO_CLONE_FUNCTION(gsMaterialMatrixTFT)
+    GISMO_OVERRIDE_CLONE_FUNCTION(gsMaterialMatrixTFT)
 
 public:
 
@@ -117,18 +117,18 @@ public:
     // { return m_materialMat; }
 
     /// See \ref gsMaterialMatrixBase for details
-    void density_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const
+    void density_into(const index_t patch, const gsMatrix<T>& u, gsMatrix<T>& result) const override
     { m_materialMat->density_into( patch,u,result ); }
 
     /// See \ref gsMaterialMatrixBase for details
-    void thickness_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const
+    void thickness_into(const index_t patch, const gsMatrix<T> & u, gsMatrix<T>& result) const override
     { m_materialMat->thickness_into( patch,u,result ); }
 
     /// See \ref gsMaterialMatrixBase for details
-    gsMatrix<T> eval3D_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const;
+    gsMatrix<T> eval3D_matrix(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
 
     /// See \ref gsMaterialMatrixBase for details
-    gsMatrix<T> eval3D_vector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const;
+    gsMatrix<T> eval3D_vector(const index_t patch, const gsMatrix<T> & u, const gsMatrix<T>& z, enum MaterialOutput out = MaterialOutput::Generic) const override;
 
     /// Returns the principal stresses stored in the underlying material model where the tension-field is non-slack
     ///
@@ -175,11 +175,11 @@ public:
     { return m_materialMat->eval3D_pstretchDir( patch,u,z ); }
 
     /// See \ref gsMaterialMatrixBase for details
-    void setParameters(const std::vector<gsFunctionSet<T>*> &pars)
+    void setParameters(const std::vector<gsFunctionSet<T>*> &pars) override
     { m_materialMat->setParameters(pars); }
 
     /// See \ref gsMaterialMatrixBase for details
-    void info() const
+    void info() const override
     { m_materialMat->info(); }
 
     /// See \ref gsMaterialMatrixBase for details

--- a/src/gsMaterialMatrixXml_.cpp
+++ b/src/gsMaterialMatrixXml_.cpp
@@ -19,85 +19,85 @@ namespace internal
     ////////////////////////////////////////////////////////////////
     // 2D compressible
     // NH
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,11,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,21,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,31,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,11,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,21,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,31,true>>;
 
     // NH_ext
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,12,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,22,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,32,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,12,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,22,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,32,true>>;
 
     // MR
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,13,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,23,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,33,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,13,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,23,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,33,true>>;
 
     // OG
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,34,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,34,true>>;
     ////////////////////////////////////////////////////////////////
     
     ////////////////////////////////////////////////////////////////
     // 3D compressible
     // NH
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,11,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,21,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,31,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,11,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,21,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,31,true>>;
 
     // NH_ext
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,12,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,22,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,32,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,12,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,22,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,32,true>>;
 
     // MR
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,13,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,23,true>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,33,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,13,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,23,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,33,true>>;
 
     // OG
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,34,true>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,34,true>>;
     ////////////////////////////////////////////////////////////////
 
     ////////////////////////////////////////////////////////////////
     // 2D incompressible
     // NH
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,11,false>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,21,false>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,31,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,11,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,21,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,31,false>>;
 
     // NH_ext
-    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,12,false>>;
-    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,22,false>>;
-    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,32,false>>;
+    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,12,false>>;
+    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,22,false>>;
+    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,32,false>>;
 
     // MR
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,13,false>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,23,false>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,33,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,13,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,23,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,33,false>>;
 
     // OG
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<2,real_t,34,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<2,real_t,34,false>>;
     ////////////////////////////////////////////////////////////////
 
     ////////////////////////////////////////////////////////////////
     // 3D incompressible
     // NH
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,11,false>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,21,false>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,31,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,11,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,21,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,31,false>>;
 
     // NH_ext
-    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,12,false>>;
-    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,22,false>>;
-    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,32,false>>;
+    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,12,false>>;
+    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,22,false>>;
+    // CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,32,false>>;
 
     // MR
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,13,false>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,23,false>>;
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,33,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,13,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,23,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,33,false>>;
 
     // OG
-    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrix<3,real_t,34,false>>;
+    CLASS_TEMPLATE_INST gsXml<gsMaterialMatrixNonlinear<3,real_t,34,false>>;
     ////////////////////////////////////////////////////////////////
 
 

--- a/src/gsThinShellAssemblerDWR.h
+++ b/src/gsThinShellAssemblerDWR.h
@@ -264,7 +264,7 @@ public:
     void setGoal(enum GoalFunction GF, short_t component = 9) { m_goalFunction = GF; m_component = component; }
 
     /// See \ref gsThinShellAssemblerBase for details
-    void constructStress(const gsMultiPatch<T> & deformed, gsPiecewiseFunction<T> & result, stress_type::type type)
+    void constructStress(const gsFunctionSet<T> & deformed, gsPiecewiseFunction<T> & result, stress_type::type type)
     {
         m_assemblerL->constructStress(deformed,result,type);
     }
@@ -360,7 +360,7 @@ protected:
                             std::string filename = std::string(), unsigned np=1000, bool parametric=false, bool mesh=false);
 
     template<int _d, bool _bending, int _elWise>
-    typename std::enable_if<(_d==3 && _bending), void>::type
+    typename std::enable_if<(_d==3) && _bending, void>::type
     computeError_impl(const gsMultiPatch<T> & dualL, const gsMultiPatch<T> & dualH, const gsMultiPatch<T> & deformed, bool withLoads,
                         std::string filename = std::string(), unsigned np=1000, bool parametric=false, bool mesh=false);
 
@@ -374,7 +374,7 @@ protected:
                             std::string filename = std::string(), unsigned np=1000, bool parametric=false, bool mesh=false);
 
     template<int _d, bool _bending, int _elWise>
-    typename std::enable_if<(_d==3 && _bending), void>::type
+    typename std::enable_if<(_d==3) && _bending, void>::type
     computeSquaredError_impl(const gsMultiPatch<T> & dualL, const gsMultiPatch<T> & dualH, const gsMultiPatch<T> & deformed, bool withLoads,
                         std::string filename = std::string(), unsigned np=1000, bool parametric=false, bool mesh=false);
 
@@ -609,7 +609,7 @@ public:
     virtual void setGoal(enum GoalFunction GF, short_t component = 9) = 0;
 
     /// See \ref gsThinShellAssemblerBase for details
-    virtual void constructStress(const gsMultiPatch<T> & deformed,
+    virtual void constructStress(const gsFunctionSet<T> & deformed,
                                gsPiecewiseFunction<T> & result,
                                stress_type::type type) = 0;
 

--- a/src/gsThinShellAssemblerDWR.hpp
+++ b/src/gsThinShellAssemblerDWR.hpp
@@ -1802,7 +1802,7 @@ std::vector<T> gsThinShellAssemblerDWR<d, T, bending>::computeErrorDofs(const gs
 
 template <short_t d, class T, bool bending>
 template<short_t _d, bool _bending, index_t _elWise>
-typename std::enable_if<(_d==3 && _bending), void>::type
+typename std::enable_if<(_d==3) && _bending, void>::type
 gsThinShellAssemblerDWR<d, T, bending>::computeError_impl(const gsMultiPatch<T> & dualL, const gsMultiPatch<T> & dualH, const gsMultiPatch<T> & deformed, bool withLoads,
                                                             // bool withLoads,
                                                             std::string filename, unsigned np, bool parametric, bool mesh)
@@ -2115,7 +2115,7 @@ std::vector<T> gsThinShellAssemblerDWR<d, T, bending>::computeSquaredErrorDofs(c
 
 template <short_t d, class T, bool bending>
 template<short_t _d, bool _bending, index_t _elWise>
-typename std::enable_if<(_d==3 && _bending), void>::type
+typename std::enable_if<(_d==3) && _bending, void>::type
 gsThinShellAssemblerDWR<d, T, bending>::computeSquaredError_impl(const gsMultiPatch<T> & dualL, const gsMultiPatch<T> & dualH, const gsMultiPatch<T> & deformed, bool withLoads,
                                                             // bool withLoads,
                                                             std::string filename, unsigned np, bool parametric, bool mesh)


### PR DESCRIPTION
Fixes compiler warnings appearing in Clang. 

Renames the `gsMaterialMatrix` to `gsMaterialMatrixNonlinear`, according to the filename.

This PR can be merged after [#694](https://github.com/gismo/gismo/pull/694) in  [gismo](https://github.com/gismo/gismo/)