### PR TITLE
Add tutorials for the `gsKLShell` module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,21 +47,17 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}"
 add_definitions(-DSHELL_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/filedata/")
 
 # add example files
-add_custom_target(${PROJECT_NAME}-examples)
-aux_cpp_directory(${CMAKE_CURRENT_SOURCE_DIR}/examples FILES)
-foreach(file ${FILES})
-    add_gismo_executable(${file})
-    get_filename_component(tarname ${file} NAME_WE) # name without extension
-    set_property(TEST ${tarname} PROPERTY LABELS "${PROJECT_NAME}")
-    set_target_properties(${tarname} PROPERTIES FOLDER "${PROJECT_NAME}")
-    add_dependencies(${PROJECT_NAME}-examples ${tarname})
-    # install the example executables (optionally)
-    install(TARGETS ${tarname} DESTINATION "${BIN_INSTALL_DIR}" COMPONENT exe OPTIONAL)
-endforeach(file ${FILES})
+if(GISMO_BUILD_EXAMPLES)
+  add_subdirectory(examples)
+  add_subdirectory(tutorials)
+else()
+  add_subdirectory(examples EXCLUDE_FROM_ALL)
+  add_subdirectory(tutorials EXCLUDE_FROM_ALL)
+endif(GISMO_BUILD_EXAMPLES)
 
 # add unittests
-aux_gs_cpp_directory(${PROJECT_SOURCE_DIR}/unittests unittests_SRCS)
-set(gismo_UNITTESTS ${gismo_UNITTESTS} ${unittests_SRCS}
-  CACHE INTERNAL "gismo list of unittests")
-
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin/)
+if(GISMO_BUILD_UNITTESTS)
+  add_subdirectory(unittests)
+else()
+  add_subdirectory(unittests EXCLUDE_FROM_ALL)
+endif(GISMO_BUILD_UNITTESTS)

--- a/doc/gsKLShell.dox
+++ b/doc/gsKLShell.dox
@@ -4,9 +4,9 @@ namespace gismo
 /** \defgroup KLShell Kirchhoff-Love shell module
 \ingroup Modules
 
-This module is about solving elasticity problems on thin shells using the Kirchhoff-Love shell formulations. References for this implementation include the original work by Kiendl et. al. (2009) [1], the PhD thesis of Josef Kiendl (2011) [2], the PhD thesis of Anmol Goyal (2015) [3], the MSc thesis of Hugo Verhelst (2019) [4]. Anmol contributed to the first Kirchhoff-Love implementation of G+Smo and Hugo to the current one.
+This module is about solving elasticity problems on thin shells using the Kirchhoff-Love shell formulations. References for this implementation include the original work by Kiendl et. al. (2009) [I], the PhD thesis of Josef Kiendl (2011) [II], the PhD thesis of Anmol Goyal (2015) [III], the MSc thesis of Hugo Verhelst (2019) [IV]. Anmol contributed to the first Kirchhoff-Love implementation of G+Smo and Hugo to the current one.
 
-\section equations Governing Equations
+\subsection klShell_Equations Governing Equations
 
 The variational formulation for the Kirchhoff-Love shell is:
 \f{eqnarray*}{
@@ -25,7 +25,7 @@ In this equation, the primed (\f$\cdot^\prime\f$) expressions again denote the f
 
 From the above equations, a system of equations can be assembled, which will later be done by the \ref gsExprAssembler . In case of a lineararized system, only the single-primed expressions are non-zero, together with the term containing the external load.
 
-The expressions for the strains, normal foce and bending moment are as follows (see sec. 3.2 and 3.3 of [3]):
+The expressions for the strains, normal foce and bending moment are as follows (see sec. 3.2 and 3.3 of [III]):
 \f{align*}{
     \varepsilon_{\alpha\beta} &= \frac{\partial\mathbf{c}}{\partial\theta_\alpha}\cdot\frac{\partial\mathbf{c}}{\partial\theta_\beta} - \frac{\partial\mathbf{C}}{\partial\theta_\alpha}\cdot\frac{\partial\mathbf{C}}{\partial\theta_\beta}\\
     \varepsilon^\prime_{\alpha\beta} &= \frac{1}{2}\frac{\partial\mathbf{v}}{\partial\theta_\alpha}\cdot\frac{\partial\mathbf{c}}{\partial\theta_\beta} + \frac{1}{2}\frac{\partial\mathbf{c}}{\partial\theta_\alpha}\cdot\frac{\partial\mathbf{v}}{\partial\theta_\beta} \\
@@ -44,20 +44,20 @@ The expressions for the strains, normal foce and bending moment are as follows (
     m_{\alpha\beta}^\prime &= \mathcal{C}^{\alpha\beta\gamma\delta} \kappa_{\alpha\beta}^{\prime}
 \f}
 
-Here, \f$ t\f$ is the thickness of the shell and \f$ \mathcal{C}^{\alpha\beta\gamma\delta}\f$ is the material tensor (see [3] eq. 3.15).
+Here, \f$ t\f$ is the thickness of the shell and \f$ \mathcal{C}^{\alpha\beta\gamma\delta}\f$ is the material tensor (see [III] eq. 3.15).
 
-\section Implementation Implementation
+\subsection klShell_Implementation Implementation
 The Kirchhoff-Love shell is implemented in the gsThinShellAssembler class and the constitutive relations are included in separate classes based on gsMaterialMatrixBase.
 
-\subsection assembler The gsThinShellAssembler
-The gsThinShellAssembler is a class that implements the \subpage kirchhoff-Love_example and adds advanced functionalities. That is, the class uses the gsExprAssembler to assemble matrices and vectors for shell modelling. Key features of the class are:
+\subsection klShell_Assembler The gsThinShellAssembler
+The gsThinShellAssembler is a class that implements the \ref kirchhoff-Love_example and adds advanced functionalities. That is, the class uses the gsExprAssembler to assemble matrices and vectors for shell modelling. Key features of the class are:
 - Geometric nonlinearities, loading nonlinearities and material nonlinearities (via the gsMaterialMatrixBase),
 - Distributed loads, point loads and follower loads (nonlinear)
 - Multipatch modelling by accepting the gsMappedBasis and gsMappedSpline
 
 The expressions for the assembly of the system of equations are partially coming from gsExpressions (e.g. the jac_expr, the grad_expr) and shell-specific expressions are implemented in the \ref gsThinShellUtils.h. Furthermore, \ref gsThinShellFunctions.h contains a helper-class for plotting the stress field within the shell.
 
-\subsection assembler The gsMaterialMatrixBase
+\subsection klShell_Materialmatrix The gsMaterialMatrixBase
 The material relations are handled in separate classes, derived from gsMaterialMatrixBase. The material matrix generally behaves as a gsFunctionSet with implemented evaluation functions. The quantities that can be computed using material matrices are the thickness, the density, the (membrane/bending) stress, the force/moment through-thickness and principal stretches or stresses. Helper classes are employed to evaluate the stress or material tensor at a point or to find the integral over the thickness. The constitutive relations currently implemented are:
 - Linear materials (Saint-Venant Kirchhoff) in gsMaterialMatrixLinear
 - Linear laminates in gsMaterialMatrixComposite
@@ -69,17 +69,17 @@ To evaluate (the integral of) any material quantity, the following classes can b
 
 Helper functions for defining material matrices are provided in \ref getMaterialMatrix.h, which constructs a pointer to a material matrix based on a gsOptionsList
 
-\section ExampleUse Use of the classes
+\subsection klShell_ExampleUse Use of the classes
 Typically, the aforementioned classes are used by first defining a gsMaterialMatrix and passing this to a gsThinShellAssembler.
 
 ~~~~~
-/// Define the material matrix options
+// Define the material matrix options
 options.addInt("Material","Material model: (0): SvK | (1): NH | (2): NH_ext | (3): MR | (4): Ogden",0);
 options.addInt("Implementation","Implementation: (0): Composites | (1): Analytical | (2): Generalized | (3): Spectral",1);
-/// Construct a material matrix pointer, for a matrix with geometric dimension DIM and T as a double type
+// Construct a material matrix pointer, for a matrix with geometric dimension DIM and T as a double type
 gsMaterialMatrixBase<T> * materialMatrix = getMaterialMatrix<DIM,T>(mp,t,parameters,rho,options);
 
-/// Construct a gsThinShellAssembler class with geometric dimension DIM, T as double type and the flag BENDING to specify whether bending stiffness should be taken into account. The
+// Construct a gsThinShellAssembler class with geometric dimension DIM, T as double type and the flag BENDING to specify whether bending stiffness should be taken into account. The
 gsThinShellAssemblerBase<real_t>* assembler;
 assembler = new gsThinShellAssembler<DIM,T, BENDING>(
         geom,
@@ -88,7 +88,7 @@ assembler = new gsThinShellAssembler<DIM,T, BENDING>(
         force,
         materialMatrix);
 
-/// Call assembly routines:
+// Call assembly routines:
 assembler->assemble();
     // Stiffness matrix
 gsSparseMatrix<T> K = assember->matrix();
@@ -108,24 +108,49 @@ assembler->assembleVector(deformed_geometry);
 gsVector<T>       R = assember->rhs();
 
 ~~~~~
-\section Examples Examples
+
+\subsection klShell_Tutorials Tutorials
+
+In the folder \c gsKLShell/tutorials, some tutorials are provided, explaining the use of the \ref gsKLShell module. The tutorials can be compiled using the target \c gsKLShell-tutorials. The available tutorials are:
+1. \ref linear_shell
+2. \ref nonlinear_shell
+
+\subsection klShell_Examples Examples
 Few examples are provided in this module
-- \subpage example_shell2D : simple 2D elasticity including nonlinear materials
-- \subpage example_shell3D : 3D shell examples including nonlinear materials
-- \subpage gsMaterialMatrix_test : simple file to demonstrate evaluation of material matrices
+- \ref example_shell2D : simple 2D elasticity including nonlinear materials
+- \ref example_shell3D : 3D shell examples including nonlinear materials
+- \ref gsMaterialMatrix_test : simple file to demonstrate evaluation of material matrices
 
-\section References References
-[1] J. Kiendl, K.-U. Bletzinger, J. Linhard, and R. Wüchner, “Isogeometric shell analysis with Kirchhoff–Love elements,” Comput. Methods Appl. Mech. Eng., vol. 198, no. 49–52, pp. 3902–3914, Nov. 2009.
 
-[2] J. Kiendl, “Isogeometric analysis and shape optimal design of shell structures,” Technische Universität München, 2011.
 
-[3] A. Goyal, “Isogeometric Shell Discretizations for Flexible Multibody Dynamics,” Technische Universität Kaiserslautern, 2015.
+\subsection klShell_References References
+[I] J. Kiendl, K.-U. Bletzinger, J. Linhard, and R. Wüchner, "Isogeometric shell analysis with Kirchhoff–Love elements," Comput. Methods Appl. Mech. Eng., vol. 198, no. 49–52, pp. 3902–3914, Nov. 2009.
 
-[4] H. M. Verhelst, “Modelling Wrinkling Behaviour of Large Floating Thin Offshore Structures: An application of Isogeometric Structural Analysis for Post-Buckling Analyses,” Delft University of Technology, 2019.
+[II] J. Kiendl, "Isogeometric analysis and shape optimal design of shell structures," Technische Universität München, 2011.
 
-[5] A. J. Herrema, E. L. Johnson, D. Proserpio, M. C. H. Wu, J. Kiendl, and M.-C. Hsu, “Penalty coupling of non-matching isogeometric Kirchhoff–Love shell patches with application to composite wind turbine blades,” Comput. Methods Appl. Mech. Eng., vol. 346, pp. 810–840, Apr. 2019.
+[III] A. Goyal, "Isogeometric Shell Discretizations for Flexible Multibody Dynamics," Technische Universität Kaiserslautern, 2015.
 
-\section Contact Contact
+[IV] H. M. Verhelst, "Modelling Wrinkling Behaviour of Large Floating Thin Offshore Structures: An application of Isogeometric Structural Analysis for Post-Buckling Analyses," Delft University of Technology, 2019.
+
+\subsection klShell_Publications Publications
+
+[8] H. M. Verhelst, "Isogeometric Analysis of Wrinkling.", PhD Thesis, TU Delft, 2024
+
+[7] H.M. Verhelst, A. Mantzaflaris, M. Möller, J.H. Den Besten, "Goal-Adaptive Meshing of Isogeometric Kirchhoff-Love Shells", Engineering with Computers, 2024
+
+[6] H.M. Verhelst, J.H. Den Besten, M. Möller, "An adaptive parallel arc-length method", Computers & Structures, 2024
+
+[5] H.M. Verhelst, P. Weinmüller, A. Mantzaflaris, T. Takacs, D. Toshniwal, "A comparison of smooth basis constructions for isogeometric analysis", Computer Methods in Applied Mechanics and Engineering, 2024
+
+[4] A. Farahat, H.M. Verhelst, J. Kiendl, M. Kapl, "Isogeometric analysis for multi-patch structured Kirchhoff–Love shells", Computer Methods in Applied Mechanics and Engineering, 2023
+
+[3] H.M. Verhelst, M. Möller, J.H. Den Besten, A. Mantzaflaris, M.L. Kaminski, "Stretch-based hyperelastic material formulations for isogeometric Kirchhoff–Love shells with application to wrinkling", Computer-Aided Design. 2021 Oct 1;139:103075.
+
+[2] H.M. Verhelst, M. Möller, J.H. Den Besten, F.J. Vermolen, M.L. Kaminski, "Equilibrium Path Analysis Including Bifurcations with an Arc-Length Method Avoiding A Priori Perturbations", Numerical Mathematics and Advanced Applications ENUMATH 2019: European Conference, Egmond aan Zee, The Netherlands, September 30-October 4. Cham: Springer International Publishing, 2020.
+
+[1] H.M. Verhelst, "Modelling Wrinkling Behaviour of Large Floating Thin Offshore Structures: An application of Isogeometric Structural Analysis for Post-Buckling Analyses.", MSc. Thesis, TU Delft, 2019.
+
+\subsection klShell_Contact Contact
 Author: Hugo Verhelst -- h.m.verhelst@tudelft.nl
 
 */

--- a/doc/linear_shell.dox
+++ b/doc/linear_shell.dox
@@ -1,0 +1,89 @@
+namespace gismo {
+/**
+
+\page linear_shell Tutorial: Linear Kirchhoff-Love shell analysis
+
+This example solves a linear shell problem using the \ref gsThinShellAssembler. The goals of the tutorial are the following:
+- Construct a \ref gsMaterialMatrixBase object, given material parameters
+- Construct a \ref gsThinShellAssembler object, given boundary conditions
+- Solve a linear problem and export the solutions
+
+\subsection linear_shell_Preliminaries Preliminaries
+Like every example in G+Smo, we start our file with some includes. In this case, we include the \c gsThinShellAssembler.h file containing the assembler for the Kirchhoff-Love shell, and the \c getMaterialMatrix.h used for getting the material matrix.
+
+\snippet linear_shell.cpp Includes
+
+The command line options for this file are relatively easy. One can control the number of mesh refinements and degree elevations, and specify a plot flag if needed.
+
+\snippet linear_shell.cpp Parse command line
+
+\subsection linear_shell_Geometry Geometry and basis
+The problem at hand will be the Scordelis-Lo Roof problem from the shell obstactle course, see <a href="https://doi.org/10.1016/j.cma.2009.08.013">this paper</a>. The geometry is stored in a file, hence it is read into the original geometry \a ori via \ref gsReadFile.
+
+\snippet linear_shell.cpp Read geometry
+
+For the analysis, we will use the geometry defined in the basis that we want for analysis. This is not essential, but it makes it easier to construct the geometry later using the \ref gsThinShellAssembler class
+
+\snippet linear_shell.cpp Initialize geometry
+
+The basis is simply obtained using \ref gsMultiBasis
+
+\snippet linear_shell.cpp Construct basis
+
+\subsection linear_shell_BCs Boundary conditions and loads
+The boundary conditions of the problem are assigned via \ref gsBoundaryConditions. On the east and west boundary of the geometry, the \f$y\f$ and \f$z\f$ displacements are fixed, and to make the problem well-defined, the south-west corner is fixed in \f$x\f$. The boundary conditions are defined by first specifying the side (\ref boxSide), then the type of condition (\ref condition_type), then the function (\c nullptr here), the unknown (always 0, since displacements are the only unknown field), whether the condition is applied in the parametric domain (always \c false) and finally the component of the solution field (-1 for all, 0 for \f$x\f$, 1 for \f$y\f$ and 2 for \f$z\f$):
+
+\snippet linear_shell.cpp Set boundary conditions
+
+The surface load on the shell is provided by a \ref gsFunctionSet, which in this case is a derived \ref gsFunctionExpr.
+
+\snippet linear_shell.cpp Set surface force
+
+\subsection linear_shell_Material Material definition
+The material law used in \ref gsThinShellAssembler is specified using a separate class, derived from \ref gsMaterialMatrixBase. The family of this class includes several material models, and can be evaluated in every point (including a thickness coordinate) using \ref gsMaterialMatrixEval or it can be integrated using \ref gsMaterialMatrixIntegrate. Depending on the options specified to the latter classes, different constitutive quantities can be obtaied, including the normal force and bending moment.
+
+To define a meterial matrix, we can use the \ref getMaterialMatrix function. This functions needs the undeformed geometry, the thickness, a set of parameters and some options:
+
+\snippet linear_shell.cpp Define the material matrix class
+
+In case of \c "Material" 0, a \ref gsMaterialMatrixLinear is provided, which only takes the Young's Modulus (\f$E\f$) and the Poisson's ratio (\f$\nu\f$). For the linear material matrix, thickness integration is simply done by multiplying with the thickness moments. For hyperelastic material models (see \ref gsMaterialMatrixNonlinear), more parameters can be required, and through-thickness integration is done numerically. We refer to the page \ref klShell_Materialmatrix for more details on material matrices.
+
+\subsection linear_shell_Assembler Assembling and solving the linear problem
+When the geometry, the basis, the boundary conditions and forces and the material are specified, the \ref gsThinShellAssembler is simply constructed as follows:
+
+\snippet linear_shell.cpp Define the assembler
+
+Here, the first template parameter is the physical dimension, the second is the real type and the third is a boolean specifying whether bending stiffness contributions should be assembled.
+
+Assemlbly of the linear stiffness matrix and external load vector is simply performed by calling
+
+\snippet linear_shell.cpp Assemble linear part
+
+Having the stiffness matrix and force vector assembled, the linear shell problem can be solved accordingly. This is done with a simple \ref gsSparseSolver:
+
+\snippet linear_shell.cpp Solve linear problem
+
+\subsection linear_shell_Export Exporting the solution
+Solving the linear problem gives the displacements of the control points of the geometry. To construct the displacement field, these control points form a solution field using the same basis as used for analysis. To construct the deformed geometry, their values need to be added to the control points of the original geometry. For ease of use, these functions are available in the \ref gsThinShellAssembler:
+
+\snippet linear_shell.cpp Construct solution and deformed geometry
+
+Using the displacement field and the deformed geometry, one can make some evaluations like with any other \ref gsFunction, \ref gsGeometry or \ref gsMultiPatch, for example to print the displacements in a point:
+
+\snippet linear_shell.cpp Evaluate solution
+
+In addition, the solutions can be exported to Paraview using \ref gsField:
+
+\snippet linear_shell.cpp Export visualization in ParaView
+
+
+\section linear_shell_Annotated Annotated source file
+
+Here is the full file \c linear_shell.cpp. Clicking on a function
+or class name will lead you to its reference documentation.
+
+\include linear_shell.cpp
+
+*/
+
+}

--- a/doc/nonlinear_shell.dox
+++ b/doc/nonlinear_shell.dox
@@ -1,0 +1,66 @@
+namespace gismo {
+/**
+
+\page nonlinear_shell Tutorial: Non-Linear Kirchhoff-Love shell analysis
+
+This example solves a non-linear shell problem using the \ref gsThinShellAssembler. The goals of the tutorial are the following:
+- Solve a geometrically non-linear problem and export the solutions
+
+For detailed information about the construction of \ref gsThinShellAssembler and \ref gsMaterialMatrixBase, please consult the tutorial \ref linear_shell.
+
+\subsection nonlinear_shell_Geometry Geometry and basis
+For the non-linear problem, we consider the paraboloid geometry, stored in the file below. Like for the \ref linear_shell, the geometry is loaded using \ref gsReadFile.
+
+\snippet nonlinear_shell.cpp Read geometry
+
+The geometry and basis refinement are the same as for \ref linear_shell.
+
+\subsection nonlinear_shell_BCs Boundary conditions and loads
+For this problem, we fix all four corners of the paraboloid, hence the boundary conditions are defined as:
+
+\snippet nonlinear_shell.cpp Set boundary conditions
+
+In addition, a point load is applied using the \ref gsPointLoads class. This point load is defined using a parametric point, and a load in the physical space:
+
+\snippet nonlinear_shell.cpp Loads
+
+\subsection nonlinear_shell_Assembler Configuration of the assembler
+The configuration of the material matrix and the shell assembler is the same as in \ref linear_shell. The only differences are that we now use a Neo-Hookean material (by passing another value to \c "Material"):
+
+\snippet nonlinear_shell.cpp Define the material matrix class
+
+And that the point loads need to be registered in the assembler, i.e.
+
+\snippet nonlinear_shell.cpp Define the assembler
+
+\subsection nonlinear_shell_Jacobian Jacobian and Residual
+For the non-linear problem, we need the tangential stiffness matrix (i.e. the Jacobian) and the residual vector. Both operators depend on the deformed configuration, through the solution vector. A convenient way of defining these operators is through an \c std::function, as is also done in the \ref gsStructuralAnalysis module:
+
+\snippet nonlinear_shell.cpp Define nonlinear residual functions
+
+Inside the functions, it can be seen that the assembler first constructs a multi-patch object of the deformed configuration, based on the solution vector, and then it assembles the Jacobian and the residual vector by passing the deformation. The resulting operators are given as arguments, and the functions return \c true if the assembly is succesful.
+
+In principle, the \ref gsThinShellAssembler always takes the geometric non-linearity into account when assembled with a deformed object as input. The same holds for the material non-linearity, since they are evaluated on the current deformation.
+
+\subsection nonlinear_shell_Solve Solving the problem
+To initialize the non-linear solve, a linear solve is performed first:
+
+\snippet nonlinear_shell.cpp Solve linear problem
+
+Afterwards, Newton-Raphson iterations are performed. The functions \c Residual and \c Jacobian are called inside \ref GISMO_ENSURE macros, guarding succesful assembly. The iterative update is performed on the solution vector, which is converted inside the \c Jacobian and \c Residual to a multi-patch.
+
+\snippet nonlinear_shell.cpp Solve nonlinear problem
+
+\subsection nonlinear_shell_Export Exporting the solution
+Finally, exporting of the solution is similar to \ref linear_shell.
+
+\section nonlinear_shell_Annotated Annotated source file
+
+Here is the full file \c nonlinear_shell.cpp. Clicking on a function
+or class name will lead you to its reference documentation.
+
+\include nonlinear_shell.cpp
+
+*/
+
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,21 @@
+######################################################################
+## CMakeLists.txt --- gsKLShell/examples
+## This file is part of the G+Smo library.
+##
+## Author: Angelos Mantzaflaris, Hugo Verhelst
+## Copyright (C) 2023
+######################################################################
+
+# add example files
+add_custom_target(${PROJECT_NAME}-examples)
+aux_cpp_directory(${CMAKE_CURRENT_SOURCE_DIR} FILES)
+foreach(file ${FILES})
+    add_gismo_executable(${file})
+    get_filename_component(tarname ${file} NAME_WE) # name without extension
+    set_property(TEST ${tarname} PROPERTY LABELS "${PROJECT_NAME}")
+    set_target_properties(${tarname} PROPERTIES FOLDER "${PROJECT_NAME}")
+    add_dependencies(${PROJECT_NAME}-examples ${tarname})
+    # install the example executables (optionally)
+    install(TARGETS ${tarname} DESTINATION "${BIN_INSTALL_DIR}" COMPONENT exe OPTIONAL)
+endforeach(file ${FILES})
+

--- a/examples/example_shell3D.cpp
+++ b/examples/example_shell3D.cpp
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
         bc.addCondition(boundary::east, condition_type::dirichlet, 0, 0 ,false, 1 );
         bc.addCondition(boundary::east, condition_type::dirichlet, 0, 0 ,false, 2 );
 
-        tmp<<0,0,-900;
+        tmp<<0,0,-90;
         // Surface forces
         gsConstantFunction<> force0(tmp,3);
         force.addPiece(force0);

--- a/filedata/surfaces/hyperboloid.xml
+++ b/filedata/surfaces/hyperboloid.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+ <!-- Geometry input: two planar 2D-Patches-->    
+    <Geometry type="TensorBSpline2" id="0">
+        <Basis type="TensorBSplineBasis2">
+        <Basis type="BSplineBasis" index="0">
+            <KnotVector degree="2">0 0 0 1 1 1 </KnotVector>
+        </Basis>
+        <Basis type="BSplineBasis" index="1">
+            <KnotVector degree="2">0 0 0 1 1 1 </KnotVector>
+        </Basis>
+        </Basis>
+        <coefs geoDim="3">
+        -0.5 -0.5 0.0
+        0.0 -0.5 -0.5
+        0.5 -0.5 0.
+        -0.5 0.0 0.5
+        0.0 0.0 0.0
+        0.5 0.0 0.5
+        -0.5 0.5 0.0
+        0.0 0.5 -0.5
+        0.5 0.5 0.0
+        </coefs>
+    </Geometry>
+    <MultiPatch parDim="2" id="1">
+        <patches type="id_range">0 0</patches>
+ </MultiPatch>
+</xml>
+ 

--- a/filedata/surfaces/paraboloid.xml
+++ b/filedata/surfaces/paraboloid.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--This file was created by G+Smo 21.12.0-->
+<xml>
+ <Geometry type="TensorBSpline2" id="0">
+  <Basis type="TensorBSplineBasis2">
+   <Basis type="BSplineBasis" index="0">
+    <KnotVector degree="2">0 0 0 1 1 1 </KnotVector>
+   </Basis>
+   <Basis type="BSplineBasis" index="1">
+    <KnotVector degree="2">0 0 0 1 1 1 </KnotVector>
+   </Basis>
+  </Basis>
+  <coefs geoDim="3">
+    0 0 0.5
+    0.5 0 1
+    1 0 0.5
+    0 0.5 1
+    0.5 0.5 1.5
+    1 0.5 1
+    0 1 0.5
+    0.5 1 1
+    1 1 0.5
+</coefs>
+ </Geometry>
+ <MultiPatch parDim="2" id="1">
+  <patches type="id_range">0 0</patches>
+  <boundary>0 1
+0 2
+0 3
+0 4
+</boundary>
+ </MultiPatch>
+</xml>
+

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -1,0 +1,21 @@
+######################################################################
+## CMakeLists.txt --- gsKLShell/tutorials
+## This file is part of the G+Smo library.
+##
+## Author: Angelos Mantzaflaris, Hugo Verhelst
+## Copyright (C) 2023
+######################################################################
+
+# add example files
+add_custom_target(${PROJECT_NAME}-tutorials)
+aux_cpp_directory(${CMAKE_CURRENT_SOURCE_DIR} FILES)
+foreach(file ${FILES})
+    add_gismo_executable(${file})
+    get_filename_component(tarname ${file} NAME_WE) # name without extension
+    set_property(TEST ${tarname} PROPERTY LABELS "${PROJECT_NAME}")
+    set_target_properties(${tarname} PROPERTIES FOLDER "${PROJECT_NAME}")
+    add_dependencies(${PROJECT_NAME}-tutorials ${tarname})
+    # install the example executables (optionally)
+    install(TARGETS ${tarname} DESTINATION "${BIN_INSTALL_DIR}" COMPONENT exe OPTIONAL)
+endforeach(file ${FILES})
+

--- a/tutorials/linear_shell.cpp
+++ b/tutorials/linear_shell.cpp
@@ -1,0 +1,158 @@
+/** @file gsKLShell/tutorials/linear_shell.cpp
+
+    @brief Tutorial for assembling the Kirchhoff-Love shell
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): H.M.Verhelst
+*/
+
+#include <gismo.h>
+
+//! [Includes]
+#include <gsKLShell/src/gsThinShellAssembler.h>
+#include <gsKLShell/src/getMaterialMatrix.h>
+//! [Includes]
+
+using namespace gismo;
+
+int main(int argc, char *argv[])
+{
+    //! [Parse command line]
+    bool plot  = false;
+    index_t numRefine  = 1;
+    index_t numElevate = 1;
+
+    gsCmdLine cmd("Linear shell tutorial.");
+    cmd.addInt( "e", "degreeElevation","Number of degree elevation steps to perform before solving (0: equalize degree in all directions)", numElevate );
+    cmd.addInt( "r", "uniformRefine", "Number of Uniform h-refinement steps to perform before solving",  numRefine );
+    cmd.addSwitch("plot", "Create a ParaView visualization file with the solution", plot);
+    try { cmd.getValues(argc,argv); } catch (int rv) { return rv; }
+    //! [Parse command line]
+
+    //! [Read geometry]
+    // Initialize [ori]ginal and [def]ormed geometry
+    gsMultiPatch<> ori;
+    std::string fileName = "surfaces/scordelis_lo_roof.xml";
+    gsReadFile<>(fileName, ori);
+    //! [Read geometry]
+
+    //! [Initialize geometry]
+    // p-refine
+    if (numElevate!=0)
+        ori.degreeElevate(numElevate);
+    // h-refine
+    for (int r =0; r < numRefine; ++r)
+        ori.uniformRefine();
+    //! [Initialize geometry]
+
+    //! [Construct basis]
+    gsMultiBasis<> bases(ori);
+    //! [Construct basis]
+
+    //! [Set boundary conditions]
+    // Define the boundary conditions object
+    gsBoundaryConditions<> bc;
+    // Set the geometry map for computation of the Dirichlet BCs
+    bc.setGeoMap(ori);
+
+    // Set the boundary conditions
+    bc.addCondition(boundary::west, condition_type::dirichlet, 0, 0 ,false, 1 );
+    bc.addCondition(boundary::west, condition_type::dirichlet, 0, 0 ,false, 2 );
+
+    bc.addCornerValue(boundary::southwest, 0.0, 0, 0); // (corner,value, patch, unknown)
+
+    bc.addCondition(boundary::east, condition_type::dirichlet, 0, 0 ,false, 1 );
+    bc.addCondition(boundary::east, condition_type::dirichlet, 0, 0 ,false, 2 );
+    //! [Set boundary conditions]
+
+    //! [Set surface force]
+    // The surface force is defined in the physical space, i.e. 3D
+    gsFunctionExpr<> force("0","0","-90",3);
+    //! [Set surface force]
+
+
+    //! [Define the material matrix class]
+    // Define material parameters
+    // The material parameters are defined in the physical domain as well (!)
+    gsConstantFunction<> E (4.32E8,3);
+    gsConstantFunction<> nu(0.0   ,3);
+    gsConstantFunction<> t (0.25  ,3);
+
+    // Define a linear material, see \ref gsMaterialMatrixLinear.h
+    // The first parameter is the physical domain dimension
+
+    // gsMaterialMatrixLinear<3,real_t> materialMatrix(ori,t,E,nu);
+
+    std::vector<gsFunctionSet<>*> parameters{&E,&nu};
+    gsOptionList options;
+    options.addInt("Material","Material model: (0): SvK | (1): NH | (2): NH_ext | (3): MR | (4): Ogden",0);
+    options.addInt("Implementation","Implementation: (0): Composites | (1): Analytical | (2): Generalized | (3): Spectral",1);
+    gsMaterialMatrixBase<real_t> * materialMatrix = getMaterialMatrix<3,real_t>(ori,t,parameters,options);
+    //! [Define the material matrix class]
+
+    //! [Define the assembler]
+    // Define the assembler.
+    // The first parameter is the physical domain dimension
+    // The second parameter is the real type
+    // The third parameter controls the bending stiffness
+    gsThinShellAssembler<3, real_t, true > assembler(ori,bases,bc,force,materialMatrix);
+    //! [Define the assembler]
+
+    //! [Assemble linear part]
+    assembler.assemble();
+    gsSparseMatrix<> matrix = assembler.matrix();
+    gsVector<> vector = assembler.rhs();
+    //! [Assemble linear part]
+
+    //! [Solve linear problem]
+    gsInfo<<"Solving system with "<<assembler.numDofs()<<" DoFs\n";
+    gsVector<> solVector;
+    gsSparseSolver<>::CGDiagonal solver;
+    solver.compute( matrix );
+    solVector = solver.solve(vector);
+    //! [Solve linear problem]
+
+    //! [Construct solution and deformed geometry]
+    gsMultiPatch<> displ = assembler.constructDisplacement(solVector);
+    gsMultiPatch<> def = assembler.constructSolution(solVector);
+    //! [Construct solution and deformed geometry]
+
+
+    //! [Evaluate solution]
+    // Evaluate the solution on a reference point (parametric coordinates)
+    // The reference points are stored column-wise
+    gsMatrix<> refPoint(2,1);
+    refPoint<<0.5,1;
+    // Compute the values
+    gsVector<> physpoint = def.patch(0).eval(refPoint);
+    gsVector<> refVals = displ.patch(0).eval(refPoint);
+    // gsInfo << "Displacement at reference point: "<<numVal<<"\n";
+    gsInfo  << "Displacement at reference point ("
+            <<ori.patch(0).eval(refPoint).transpose()<<"): "
+            <<": "<<refVals.transpose()<<"\n";
+    //! [Evaluate solution]
+
+    // ! [Export visualization in ParaView]
+    if (plot)
+    {
+        // Plot the displacements on the deformed geometry
+        gsField<> solField(def, displ);
+        gsInfo<<"Plotting in Paraview...\n";
+        gsWriteParaview<>( solField, "Deformation", 1000, true);
+
+        // Plot the membrane Von-Mises stresses on the geometry
+        gsPiecewiseFunction<> VMm;
+        assembler.constructStress(def,VMm,stress_type::von_mises_membrane);
+        gsField<> membraneStress(def,VMm, true);
+        gsWriteParaview(membraneStress,"MembraneStress",1000);
+    }
+    // ! [Export visualization in ParaView]
+
+    return EXIT_SUCCESS;
+
+}// end main

--- a/tutorials/linear_shell.cpp
+++ b/tutorials/linear_shell.cpp
@@ -14,8 +14,7 @@
 #include <gismo.h>
 
 //! [Includes]
-#include <gsKLShell/src/gsThinShellAssembler.h>
-#include <gsKLShell/src/getMaterialMatrix.h>
+#include <gsKLShell/gsKLShell.h>
 //! [Includes]
 
 using namespace gismo;

--- a/tutorials/nonlinear_shell.cpp
+++ b/tutorials/nonlinear_shell.cpp
@@ -1,0 +1,213 @@
+/** @file gsKLShell/tutorials/nonlinear_shell.cpp
+
+    @brief Tutorial for assembling the Non-Linear Kirchhoff-Love shell
+
+    This file is part of the G+Smo library.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    Author(s): H.M.Verhelst
+*/
+
+#include <gismo.h>
+
+//! [Includes]
+#include <gsKLShell/src/gsThinShellAssembler.h>
+#include <gsKLShell/src/getMaterialMatrix.h>
+//! [Includes]
+
+using namespace gismo;
+
+int main(int argc, char *argv[])
+{
+    //! [Parse command line]
+    bool plot  = false;
+    index_t numRefine  = 1;
+    index_t numElevate = 1;
+
+    gsCmdLine cmd("Nonlinear shell tutorial.");
+    cmd.addInt( "e", "degreeElevation","Number of degree elevation steps to perform before solving (0: equalize degree in all directions)", numElevate );
+    cmd.addInt( "r", "uniformRefine", "Number of Uniform h-refinement steps to perform before solving",  numRefine );
+    cmd.addSwitch("plot", "Create a ParaView visualization file with the solution", plot);
+    try { cmd.getValues(argc,argv); } catch (int rv) { return rv; }
+    //! [Parse command line]
+
+    //! [Read geometry]
+    // Initialize [ori]ginal and [def]ormed geometry
+    gsMultiPatch<> ori;
+    gsReadFile<>("surfaces/paraboloid.xml", ori);
+    ori.computeTopology();
+    //! [Read geometry]
+
+    //! [Initialize geometry]
+    // p-refine
+    if (numElevate!=0)
+        ori.degreeElevate(numElevate);
+    // h-refine
+    for (int r =0; r < numRefine; ++r)
+        ori.uniformRefine();
+    //! [Initialize geometry]
+
+    //! [Construct basis]
+    gsMultiBasis<> bases(ori);
+    //! [Construct basis]
+
+    //! [Set boundary conditions]
+    // Define the boundary conditions object
+    gsBoundaryConditions<> bc;
+    // Set the geometry map for computation of the Dirichlet BCs
+    bc.setGeoMap(ori);
+
+    // Set the boundary conditions
+    bc.addCornerValue(boundary::southwest, 0.0, 0, -1); // (corner,value, patch, unknown)
+    bc.addCornerValue(boundary::southeast, 0.0, 0, -1); // (corner,value, patch, unknown)
+    bc.addCornerValue(boundary::northwest, 0.0, 0, -1); // (corner,value, patch, unknown)
+    bc.addCornerValue(boundary::northeast, 0.0, 0, -1); // (corner,value, patch, unknown)
+    //! [Set boundary conditions]
+
+    //! [Loads]
+    // Point loads are defined using a point in the parametric domain, and a 3D load.
+    gsPointLoads<real_t> pLoads = gsPointLoads<real_t>();
+    gsVector<> point(2);
+    gsVector<> load (3);
+    point<< 0.5, 0.5 ; load << 0, 0.0, -1e4 ;
+    pLoads.addLoad(point, load, 0 );
+
+    // The surface force is zero, and defined in the physical space, i.e. 3D
+    gsFunctionExpr<> force("0","0","0",3);
+    //! [Loads]
+
+
+    //! [Define the material matrix class]
+    // Define material parameters
+    // The material parameters are defined in the physical domain as well (!)
+    gsConstantFunction<> E (1.E9,3);
+    gsConstantFunction<> nu(0.45,3);
+    gsConstantFunction<> t (1E-2,3);
+
+    // Define a linear material, see \ref gsMaterialMatrixLinear.h
+    // The first parameter is the physical domain dimension
+
+    // gsMaterialMatrixLinear<3,real_t> materialMatrix(ori,t,E,nu);
+
+    std::vector<gsFunctionSet<>*> parameters{&E,&nu};
+    gsOptionList options;
+    options.addInt("Material","Material model: (0): SvK | (1): NH | (2): NH_ext | (3): MR | (4): Ogden",1);
+    options.addInt("Implementation","Implementation: (0): Composites | (1): Analytical | (2): Generalized | (3): Spectral",1);
+    gsMaterialMatrixBase<real_t> * materialMatrix = getMaterialMatrix<3,real_t>(ori,t,parameters,options);
+    //! [Define the material matrix class]
+
+    //! [Define the assembler]
+    // Define the assembler.
+    // The first parameter is the physical domain dimension
+    // The second parameter is the real type
+    // The third parameter controls the bending stiffness
+    gsThinShellAssembler<3, real_t, true > assembler(ori,bases,bc,force,materialMatrix);
+    assembler.setPointLoads(pLoads);
+    //! [Define the assembler]
+
+
+    //! [Define nonlinear residual functions]
+    typedef std::function<bool (gsVector<real_t> const &, gsSparseMatrix<real_t>&)>    Jacobian_t;
+    typedef std::function<bool (gsVector<real_t> const &, gsVector<real_t>      &) >   Residual_t;
+
+    Jacobian_t Jacobian = [&assembler](gsVector<real_t> const &x, gsSparseMatrix<real_t> & m)
+    {
+        gsMultiPatch<> def;
+        assembler.constructSolution(x,def);
+        ThinShellAssemblerStatus status = assembler.assembleMatrix(def);
+        m = assembler.matrix();
+        return status==ThinShellAssemblerStatus::Success;
+    };
+    // Function for the Residual
+    Residual_t Residual = [&assembler](gsVector<real_t> const &x, gsVector<real_t> & v)
+    {
+        gsMultiPatch<> def;
+        assembler.constructSolution(x,def);
+        ThinShellAssemblerStatus status = assembler.assembleVector(def);
+        v = assembler.rhs();
+        return status==ThinShellAssemblerStatus::Success;
+    };
+    //! [Define nonlinear residual functions]
+
+
+    //! [Assemble linear part]
+    assembler.assemble();
+    gsSparseMatrix<> matrix = assembler.matrix();
+    gsVector<> F = assembler.rhs();
+    //! [Assemble linear part]
+
+    //! [Solve linear problem]
+    gsInfo<<"Solving system with "<<assembler.numDofs()<<" DoFs\n";
+    gsVector<> solVector;
+    gsSparseSolver<>::CGDiagonal solver;
+    solver.compute( matrix );
+    solVector = solver.solve(F);
+    //! [Solve linear problem]
+
+    //! [Solve nonlinear problem]
+    gsVector<> updateVector = solVector;
+    gsVector<> R;
+    GISMO_ENSURE(Residual(solVector,R),"Assembly of the residual failed");
+    for (index_t it = 0; it != 100; ++it)
+    {
+        GISMO_ENSURE(Jacobian(solVector,matrix),"Assembly of the Jacobian failed");
+        solver.compute(matrix);
+        updateVector = solver.solve(R); // this is the UPDATE
+        solVector += updateVector;
+
+        GISMO_ENSURE(Residual(solVector,R),"Assembly of the residual failed");
+
+        gsInfo<<"Iteration: "<< it
+           <<", residue: "<< R.norm()/F.norm()
+           <<", update norm: "<<updateVector.norm()/solVector.norm()
+           <<"\n";
+
+        if (updateVector.norm() < 1e-6)
+            break;
+        else if (it+1 == it)
+            gsWarn<<"Maximum iterations reached!\n";
+    }
+    //! [Solve nonlinear problem]
+
+    //! [Construct solution and deformed geometry]
+    gsMultiPatch<> displ = assembler.constructDisplacement(solVector);
+    gsMultiPatch<> def = assembler.constructSolution(solVector);
+    //! [Construct solution and deformed geometry]
+
+
+    //! [Evaluate solution]
+    // Evaluate the solution on a reference point (parametric coordinates)
+    // The reference points are stored column-wise
+    gsMatrix<> refPoint(2,1);
+    refPoint<<0.5,0.5;
+    // Compute the values
+    gsVector<> physpoint = def.patch(0).eval(refPoint);
+    gsVector<> refVals = displ.patch(0).eval(refPoint);
+    // gsInfo << "Displacement at reference point: "<<numVal<<"\n";
+    gsInfo  << "Displacement at reference point ("
+            <<ori.patch(0).eval(refPoint).transpose()<<"): "
+            <<": "<<refVals.transpose()<<"\n";
+    //! [Evaluate solution]
+
+    // ! [Export visualization in ParaView]
+    if (plot)
+    {
+        // Plot the displacements on the deformed geometry
+        gsField<> solField(def, displ);
+        gsInfo<<"Plotting in Paraview...\n";
+        gsWriteParaview<>( solField, "Deformation", 1000, true);
+
+        // Plot the membrane Von-Mises stresses on the geometry
+        gsPiecewiseFunction<> VMm;
+        assembler.constructStress(def,VMm,stress_type::von_mises_membrane);
+        gsField<> membraneStress(def,VMm, true);
+        gsWriteParaview(membraneStress,"MembraneStress",1000);
+    }
+    // ! [Export visualization in ParaView]
+
+    return EXIT_SUCCESS;
+
+}// end main

--- a/tutorials/nonlinear_shell.cpp
+++ b/tutorials/nonlinear_shell.cpp
@@ -14,8 +14,7 @@
 #include <gismo.h>
 
 //! [Includes]
-#include <gsKLShell/src/gsThinShellAssembler.h>
-#include <gsKLShell/src/getMaterialMatrix.h>
+#include <gsKLShell/gsKLShell.h>
 //! [Includes]
 
 using namespace gismo;

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,0 +1,14 @@
+######################################################################
+## CMakeLists.txt --- gsKLShell/examples
+## This file is part of the G+Smo library.
+##
+## Author: Angelos Mantzaflaris, Hugo Verhelst
+## Copyright (C) 2023
+######################################################################
+
+# add unittests
+aux_gs_cpp_directory(${PROJECT_SOURCE_DIR} unittests_SRCS)
+set(gismo_UNITTESTS ${gismo_UNITTESTS} ${unittests_SRCS}
+  CACHE INTERNAL "gismo list of unittests")
+
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin/)


### PR DESCRIPTION
ADD:
- Tutorial `linear_shell` and `nonlinear_shell`

IMPROVED:
- CMakeLists per sub-directory, using `GISMO_BUILD_EXAMPLES` flag
- Doxygen documentation