### PR TITLE
Change checkout reference from 'stable' to 'dev'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           repository: gismo/gismo
-          ref: stable
+          ref: dev
           path: ./gismo
 
       - uses: actions/checkout@master


### PR DESCRIPTION
In the CI, checkout gismo in `dev` instead of `stable` branch